### PR TITLE
feat: Add directional lights on F0

### DIFF
--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -35,6 +35,14 @@
 #define MOTOR_BEMF_A_PIN A3
 #define MOTOR_BEMF_B_PIN A2
 
+// =====================================================================================
+// Licht-Konfiguration
+// =====================================================================================
+// Definieren Sie hier die Pins für die richtungsabhängige Beleuchtung.
+#define LIGHT_PIN_FWD 26 // Licht vorne
+#define LIGHT_PIN_REV 27 // Licht hinten
+#define LIGHT_BRIGHTNESS 255 // Helligkeit (0-255)
+
 
 // =====================================================================================
 // Motor-Konfiguration für xDuinoRails_MotorControl

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -5,18 +5,40 @@
 // Globales Motor-Objekt erstellen
 XDuinoRails_MotorDriver motor(MOTOR_PIN_A, MOTOR_PIN_B, MOTOR_BEMF_A_PIN, MOTOR_BEMF_B_PIN);
 
+// Zustand der Beleuchtung (F0)
+bool f0_state = true; // Lichter sind beim Start an
+
+// Funktion zur Steuerung der Lichter
+void updateLights() {
+  if (!f0_state) {
+    // Lichter sind ausgeschaltet
+    analogWrite(LIGHT_PIN_FWD, 0);
+    analogWrite(LIGHT_PIN_REV, 0);
+    return;
+  }
+
+  if (motor.getDirection()) { // true == vorwärts
+    analogWrite(LIGHT_PIN_FWD, LIGHT_BRIGHTNESS);
+    analogWrite(LIGHT_PIN_REV, 0);
+  } else { // false == rückwärts
+    analogWrite(LIGHT_PIN_FWD, 0);
+    analogWrite(LIGHT_PIN_REV, LIGHT_BRIGHTNESS);
+  }
+}
+
+
 #if defined(PROTOCOL_DCC)
 #define NMRA_DCC_PROCESS_MULTIFUNCTION
 #include <NmraDcc.h>
 
 #define DCC_SIGNAL_PIN 7
-#define HEADLIGHT_PIN 3
 
 NmraDcc dcc;
 
 void notifyDccSpeed(uint16_t Addr, DCC_ADDR_TYPE AddrType, uint8_t Speed, DCC_DIRECTION Dir, DCC_SPEED_STEPS SpeedSteps) {
   if (Addr == dcc.getAddr()) {
     motor.setDirection(Dir == DCC_DIR_FWD);
+    updateLights(); // Lichtstatus nach Richtungsänderung aktualisieren
     int pps = map(Speed, 0, 255, 0, 200);
     motor.setTargetSpeed(pps);
   }
@@ -25,11 +47,8 @@ void notifyDccSpeed(uint16_t Addr, DCC_ADDR_TYPE AddrType, uint8_t Speed, DCC_DI
 void notifyDccFunc(uint16_t Addr, DCC_ADDR_TYPE AddrType, FN_GROUP FuncGrp, uint8_t FuncState) {
   if (Addr == dcc.getAddr()) {
     if (FuncGrp == FN_0_4) {
-      if (FuncState & FN_BIT_00) {
-        digitalWrite(HEADLIGHT_PIN, HIGH);
-      } else {
-        digitalWrite(HEADLIGHT_PIN, LOW);
-      }
+      f0_state = (FuncState & FN_BIT_00);
+      updateLights();
     }
   }
 }
@@ -48,13 +67,17 @@ void mm_isr() {
 #endif
 
 void setup() {
+  pinMode(LIGHT_PIN_FWD, OUTPUT);
+  pinMode(LIGHT_PIN_REV, OUTPUT);
+
   motor.begin();
   motor.setAcceleration(MOTOR_ACCELERATION);
   motor.setDeceleration(MOTOR_DECELERATION);
   motor.setStartupKick(MOTOR_STARTUP_KICK_PWM, MOTOR_STARTUP_KICK_DURATION);
 
+  updateLights(); // Initiale Licht-Einstellung
+
 #if defined(PROTOCOL_DCC)
-  pinMode(HEADLIGHT_PIN, OUTPUT);
   dcc.pin(DCC_SIGNAL_PIN, false);
   dcc.init(MAN_ID_DIY, 1, FLAGS_MY_ADDRESS_ONLY, 0);
   dcc.setCV(CV_MULTIFUNCTION_PRIMARY_ADDRESS, 3);
@@ -70,8 +93,13 @@ void loop() {
   MM.Parse();
   MaerklinMotorolaData* data = MM.GetData();
   if (data && !data->IsMagnet && data->Address == MM_ADDRESS) {
+    // Lichtstatus auswerten
+    f0_state = data->Function;
+    updateLights();
+
     if (data->ChangeDir) {
       motor.setDirection(!motor.getDirection());
+      updateLights(); // Licht nach Richtungswechsel umschalten
     } else if (data->Stop) {
       motor.setTargetSpeed(0);
     } else {


### PR DESCRIPTION
Adds two directional light outputs, one for forward and one for reverse, controlled by function F0.

- The light pins are defined in `firmware/src/config.h` as `LIGHT_PIN_FWD` and `LIGHT_PIN_REV`.
- The brightness of the lights can be configured using the `LIGHT_BRIGHTNESS` constant in `config.h`.
- The lights are on by default when the decoder powers up.
- The functionality is implemented for both DCC and Märklin-Motorola protocols.