### PR TITLE
docs: Add English translation of MM_Decoder_Checklist

### DIFF
--- a/docs/MM_Decoder_Checklist.en.md
+++ b/docs/MM_Decoder_Checklist.en.md
@@ -1,0 +1,64 @@
+# Checklist for the Märklin-Motorola (MM) Decoder
+
+This document describes the necessary steps to develop a fully functional Märklin-Motorola decoder based on the Seeed Studio XIAO RP2040.
+
+## Phase 1: Minimal Viable Product (MVP) - MM Functionality
+
+The goal of this phase is to create a decoder that can control a locomotive using the Märklin-Motorola protocol (driving only).
+
+- [x] **1. Project Setup and Library Integration**
+    - [x] Integrate the `LaserLight/MaerklinMotorola` library as a Git submodule or via the PlatformIO Library Manager.
+    - [x] Implement a switch between DCC and MM protocols using compiler flags.
+        - [x] **Suggestion:** Define two environments in `platformio.ini`: `[env:xiao_dcc]` and `[env:xiao_mm]`.
+        - [x] **Suggestion:** Set build flags `-DPROTOCOL_DCC` and `-DPROTOCOL_MM` in the respective environments.
+    - [x] Ensure that the code can be compiled separately for both protocols by wrapping the protocol-specific logic with `#ifdef PROTOCOL_DCC` / `#endif` and `#ifdef PROTOCOL_MM` / `#endif`.
+    - [x] Only include and initialize the `NmraDcc` library if `PROTOCOL_DCC` is defined.
+    - [x] Only include and initialize the `MaerklinMotorola` library if `PROTOCOL_MM` is defined.
+
+- [x] **2. Implementation of Motor Control (Open-Loop PWM)**
+    - [x] Define the hardware pins for the H-bridge control on the XIAO RP2040.
+    - [x] Implement simple PWM functionality to regulate the motor's speed.
+    - [x] Create a function to control the direction of travel by reversing the polarity of the H-bridge.
+    - [x] Read the speed and direction commands from the `MaerklinMotorola` library and pass them to the PWM and direction logic.
+
+- [x] **3. Adapt GitHub Actions Workflow**
+    - [x] Extend the `build.yml` workflow file.
+    - [x] Create two separate build jobs: one for the DCC version (`pio run -e xiao_dcc`) and one for the MM version (`pio run -e xiao_mm`).
+    - [x] Save the compiled firmware files (`firmware.bin` or `firmware.uf2`) of both jobs as separate "Release Assets" or build artifacts (e.g., `firmware_dcc.bin` and `firmware_mm.bin`).
+
+## Phase 2: Future Extensions
+
+- [x] **1. Advanced Motor Control**
+    - [x] Integrate the `chatelao/xDuinoRails_MotorControl` library into the project.
+    - [x] Replace the simple PWM control with the advanced regulation (e.g., PID control for load compensation) from the new library.
+
+- [x] **2. Function Outputs**
+    - [x] Implement control for at least one function output (e.g., for lights).
+    - [x] Evaluate the function commands (F0, F1, etc.) from the `MaerklinMotorola` library.
+
+- [ ] **3. Multi-protocol Capability (Simultaneous Operation)**
+    - [ ] Extend the decoder to automatically distinguish between DCC and MM signals at runtime.
+    - [ ] Create a common interface for motor and function control that can be used by both protocol implementations.
+
+- [ ] **4. Configurability**
+    - [ ] Create a way to program the decoder's MM address (e.g., via a "programming mode").
+    - [ ] Add configurable parameters such as acceleration and braking delay (ABV).
+
+## Phase 3: Implementation of Light and Aux Functions
+
+- [ ] **1. Core Infrastructure**
+    - [ ] Implement the core classes for Physical Outputs and Logical Functions.
+    - [ ] Implement the `LightEffect` base class and the simplest effects: `Steady` and `Dimming`.
+    - [ ] Implement a basic, direct mapping system to allow F-keys to turn logical functions on and off.
+- [ ] **2. Advanced Effects & Mapping**
+    - [ ] Implement the full, multi-level table logic for function mapping.
+    - [ ] Implement all remaining advanced lighting effects (Flicker, Strobe, Mars Light, etc.).
+    - [ ] Develop a comprehensive CV table to configure all new features.
+- [ ] **3. Auxiliary Functions**
+    - [ ] Implement the `SERVO_CONTROL` effect.
+    - [ ] Implement the `SMOKE_GENERATOR` effect, including speed-synchronized fan control.
+    - [ ] Add CVs for configuring these new auxiliary functions.
+- [ ] **4. Tooling & Refinement**
+    - [ ] Develop a PC-based configuration tool to simplify the CV programming process.
+    - [ ] Write comprehensive user documentation for all features.
+    - [ ] Refine and optimize the code based on community feedback.

--- a/docs/MM_Decoder_Checklist.md
+++ b/docs/MM_Decoder_Checklist.md
@@ -6,35 +6,35 @@ Dieses Dokument beschreibt die notwendigen Schritte, um einen voll funktionsfäh
 
 Ziel dieser Phase ist es, einen Decoder zu erstellen, der eine Lok mit dem Märklin-Motorola-Protokoll steuern kann (nur Fahren).
 
-- [ ] **1. Projekt-Setup und Bibliotheks-Integration**
-    - [ ] Die `LaserLight/MaerklinMotorola` Bibliothek als Git-Submodul oder über den PlatformIO Library Manager in das Projekt integrieren.
-    - [ ] Eine Umschaltmöglichkeit zwischen DCC- und MM-Protokoll mittels Compiler-Flags implementieren.
-        - **Vorschlag:** In `platformio.ini` zwei Umgebungen definieren: `[env:xiao_dcc]` und `[env:xiao_mm]`.
-        - **Vorschlag:** Build-Flags `-DPROTOCOL_DCC` und `-DPROTOCOL_MM` in den jeweiligen Umgebungen setzen.
-    - [ ] Sicherstellen, dass der Code für beide Protokolle separat kompiliert werden kann, indem die protokollspezifische Logik mit `#ifdef PROTOCOL_DCC` / `#endif` und `#ifdef PROTOCOL_MM` / `#endif` umschlossen wird.
-    - [ ] Die `NmraDcc` Bibliothek nur dann einbinden und initialisieren, wenn `PROTOCOL_DCC` definiert ist.
-    - [ ] Die `MaerklinMotorola` Bibliothek nur dann einbinden und initialisieren, wenn `PROTOCOL_MM` definiert ist.
+- [x] **1. Projekt-Setup und Bibliotheks-Integration**
+    - [x] Die `LaserLight/MaerklinMotorola` Bibliothek als Git-Submodul oder über den PlatformIO Library Manager in das Projekt integrieren.
+    - [x] Eine Umschaltmöglichkeit zwischen DCC- und MM-Protokoll mittels Compiler-Flags implementieren.
+        - [x] **Vorschlag:** In `platformio.ini` zwei Umgebungen definieren: `[env:xiao_dcc]` und `[env:xiao_mm]`.
+        - [x] **Vorschlag:** Build-Flags `-DPROTOCOL_DCC` und `-DPROTOCOL_MM` in den jeweiligen Umgebungen setzen.
+    - [x] Sicherstellen, dass der Code für beide Protokolle separat kompiliert werden kann, indem die protokollspezifische Logik mit `#ifdef PROTOCOL_DCC` / `#endif` und `#ifdef PROTOCOL_MM` / `#endif` umschlossen wird.
+    - [x] Die `NmraDcc` Bibliothek nur dann einbinden und initialisieren, wenn `PROTOCOL_DCC` definiert ist.
+    - [x] Die `MaerklinMotorola` Bibliothek nur dann einbinden und initialisieren, wenn `PROTOCOL_MM` definiert ist.
 
-- [ ] **2. Implementierung der Motorsteuerung (Open-Loop PWM)**
-    - [ ] Die Hardware-Pins für die H-Brücken-Ansteuerung am XIAO RP2040 definieren.
-    - [ ] Eine einfache PWM-Funktionalität implementieren, um die Geschwindigkeit des Motors zu regeln.
-    - [ ] Eine Funktion erstellen, die die Fahrtrichtung durch Umpolen der H-Brücke steuert.
-    - [ ] Die Geschwindigkeits- und Richtungsbefehle aus der `MaerklinMotorola` Bibliothek auslesen und an die PWM- und Richtungs-Logik weitergeben.
+- [x] **2. Implementierung der Motorsteuerung (Open-Loop PWM)**
+    - [x] Die Hardware-Pins für die H-Brücken-Ansteuerung am XIAO RP2040 definieren.
+    - [x] Eine einfache PWM-Funktionalität implementieren, um die Geschwindigkeit des Motors zu regeln.
+    - [x] Eine Funktion erstellen, die die Fahrtrichtung durch Umpolen der H-Brücke steuert.
+    - [x] Die Geschwindigkeits- und Richtungsbefehle aus der `MaerklinMotorola` Bibliothek auslesen und an die PWM- und Richtungs-Logik weitergeben.
 
-- [ ] **3. GitHub Actions Workflow anpassen**
-    - [ ] Die `build.yml` Workflow-Datei erweitern.
-    - [ ] Zwei separate Build-Jobs erstellen: einen für die DCC-Version (`pio run -e xiao_dcc`) und einen für die MM-Version (`pio run -e xiao_mm`).
-    - [ ] Die kompilierten Firmware-Dateien (`firmware.bin` oder `firmware.uf2`) beider Jobs als separate "Release Assets" oder Build-Artefakte speichern (z.B. `firmware_dcc.bin` und `firmware_mm.bin`).
+- [x] **3. GitHub Actions Workflow anpassen**
+    - [x] Die `build.yml` Workflow-Datei erweitern.
+    - [x] Zwei separate Build-Jobs erstellen: einen für die DCC-Version (`pio run -e xiao_dcc`) und einen für die MM-Version (`pio run -e xiao_mm`).
+    - [x] Die kompilierten Firmware-Dateien (`firmware.bin` oder `firmware.uf2`) beider Jobs als separate "Release Assets" oder Build-Artefakte speichern (z.B. `firmware_dcc.bin` und `firmware_mm.bin`).
 
 ## Phase 2: Zukünftige Erweiterungen
 
-- [ ] **1. Fortgeschrittene Motorsteuerung**
-    - [ ] Die `chatelao/xDuinoRails_MotorControl` Bibliothek in das Projekt integrieren.
-    - [ ] Die einfache PWM-Steuerung durch die fortgeschrittene Regelung (z.B. PID-Regelung für Lastausgleich) aus der neuen Bibliothek ersetzen.
+- [x] **1. Fortgeschrittene Motorsteuerung**
+    - [x] Die `chatelao/xDuinoRails_MotorControl` Bibliothek in das Projekt integrieren.
+    - [x] Die einfache PWM-Steuerung durch die fortgeschrittene Regelung (z.B. PID-Regelung für Lastausgleich) aus der neuen Bibliothek ersetzen.
 
-- [ ] **2. Funktionsausgänge**
-    - [ ] Ansteuerung für mindestens einen Funktionsausgang (z.B. für Licht) implementieren.
-    - [ ] Die Funktionsbefehle (F0, F1, etc.) aus der `MaerklinMotorola` Bibliothek auswerten.
+- [x] **2. Funktionsausgänge**
+    - [x] Ansteuerung für mindestens einen Funktionsausgang (z.B. für Licht) implementieren.
+    - [x] Die Funktionsbefehle (F0, F1, etc.) aus der `MaerklinMotorola` Bibliothek auswerten.
 
 - [ ] **3. Multiprotokoll-Fähigkeit (Gleichzeitiger Betrieb)**
     - [ ] Den Decoder so erweitern, dass er zur Laufzeit automatisch zwischen DCC- und MM-Signalen unterscheiden kann.
@@ -43,3 +43,22 @@ Ziel dieser Phase ist es, einen Decoder zu erstellen, der eine Lok mit dem Märk
 - [ ] **4. Konfigurierbarkeit**
     - [ ] Eine Möglichkeit schaffen, die MM-Adresse des Decoders zu programmieren (z.B. über einen "Programmiermodus").
     - [ ] Konfigurierbare Parameter wie Anfahr- und Bremsverzögerung (ABV) hinzufügen.
+
+## Phase 3: Implementierung von Licht- und Aux-Funktionen
+
+- [ ] **1. Kern-Infrastruktur**
+    - [ ] Implementierung der Kern-Klassen für physische Ausgänge und logische Funktionen.
+    - [ ] Implementierung der `LightEffect`-Basisklasse und der einfachsten Effekte: `Konstant` und `Dimmen`.
+    - [ ] Implementierung eines einfachen, direkten Mapping-Systems, um F-Tasten das Ein- und Ausschalten von logischen Funktionen zu ermöglichen.
+- [ ] **2. Erweiterte Effekte & Mapping**
+    - [ ] Implementierung der vollständigen, mehrstufigen Tabellenlogik für das Funktions-Mapping.
+    - [ ] Implementierung aller verbleibenden erweiterten Lichteffekte (Flimmern, Blitz, Marslicht, etc.).
+    - [ ] Entwicklung einer umfassenden CV-Tabelle zur Konfiguration aller neuen Funktionen.
+- [ ] **3. Hilfsfunktionen**
+    - [ ] Implementierung des `SERVO_CONTROL`-Effekts.
+    - [ ] Implementierung des `SMOKE_GENERATOR`-Effekts, einschließlich geschwindigkeitssynchronisierter Lüftersteuerung.
+    - [ ] Hinzufügen von CVs zur Konfiguration dieser neuen Hilfsfunktionen.
+- [ ] **4. Werkzeuge & Verfeinerung**
+    - [ ] Entwicklung eines PC-basierten Konfigurationstools zur Vereinfachung der CV-Programmierung.
+    - [ ] Erstellung einer umfassenden Benutzerdokumentation für alle Funktionen.
+    - [ ] Verfeinerung und Optimierung des Codes basierend auf Community-Feedback.


### PR DESCRIPTION
Created a new file `MM_Decoder_Checklist.en.md` which is an English version of the German checklist. This will make the documentation accessible to a wider audience.