### PR TITLE
feat: Unify and improve README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
-# xDuinoRails_Apollo
-DCC locomotive decoder HW &amp; SW
+# xDuinoRails_Apollo: A Multi-Protocol Locomotive Decoder
+
+This repository contains the documentation, schematics, and source code for the xDuinoRails_Apollo, a multi-protocol (DCC and Märklin-Motorola) locomotive decoder.
+
+## Features
+
+*   **Multi-Protocol Support:** Supports both DCC and Märklin-Motorola (MM) protocols.
+*   **Advanced Motor Control:** Utilizes the `xDuinoRails_MotorControl` library for advanced, closed-loop motor control.
+*   **Flexible Function Mapping:** The `FunctionManager` allows for declarative mapping of function keys to physical outputs and behaviors.
+*   **Modern Hardware:** The decoder is designed for the Seeed Studio XIAO RP2040 microcontroller.
+
+## Repository Structure
+
+*   `docs/`: Contains all project documentation, including concepts for the sound and light systems.
+*   `firmware/`: Contains the PlatformIO project for the decoder's firmware.
+*   `hardware/`: Contains schematics, wiring diagrams, and other hardware-related files.
+
+## Getting Started
+
+### Hardware
+
+The decoder is designed for the Seeed Studio XIAO RP2040. You can find more information about the hardware in the `hardware/` directory.
+
+### Firmware
+
+The firmware is a PlatformIO project. To build the firmware, you will need to have PlatformIO installed.
+
+1.  **Install PlatformIO:** If you don't have it installed, you can install it via pip:
+    ```bash
+    pip install platformio
+    ```
+2.  **Build the firmware:** You can build the firmware for a specific protocol using the following command:
+    ```bash
+    # For DCC
+    python -m platformio run -d firmware -e xiao_dcc
+
+    # For Märklin-Motorola
+    python -m platformio run -d firmware -e xiao_mm
+    ```
+
+## Long-Term Vision
+
+This project has a long-term vision that includes:
+
+*   A state-of-the-art, polyphonic sound system.
+*   A state-of-the-art light and auxiliary function management system.
+*   RailCom support.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,0 @@
-# Documentation
-
-This directory contains all the documentation for the DCC locomotive decoder project.

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -1,3 +1,0 @@
-# Firmware
-
-This directory will contain the firmware for the RP2040-based DCC locomotive decoder.


### PR DESCRIPTION
Creates a single, comprehensive README.md in the root of the repository to serve as a central point of information for the project.

-   Adds a detailed project description, feature list, repository structure overview, and getting started instructions.
-   Removes the redundant placeholder README.md files from the `docs/` and `firmware/` directories.

Note: The `hardware/README.md` file could not be removed due to a persistent issue with the tooling that caused the entire parent directory to be deleted. This file has been left in place to avoid further errors.