### PR TITLE
feat: Add caching to GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,24 @@ jobs:
       with:
         python-version: '3.9'
 
+    - name: Cache pip packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
     - name: Install PlatformIO
       run: |
         python -m pip install --upgrade pip
         pip install -U platformio
+
+    - name: Cache PlatformIO dependencies
+      uses: actions/cache@v4
+      with:
+        path: firmware/.pio
+        key: ${{ runner.os }}-${{ hashFiles('firmware/platformio.ini') }}
 
     - name: Build Firmware (${{ matrix.protocol }})
       run: pio run -d firmware -e xiao_${{ matrix.protocol }}


### PR DESCRIPTION
Adds caching for pip packages and PlatformIO dependencies to the `build.yml` workflow. This will speed up the build process by reusing dependencies from previous runs.