### PR TITLE
docs: Align with RCN-227 and translate standards

### DIFF
--- a/docs/LIGHT_AND_AUX_CONCEPT.MD
+++ b/docs/LIGHT_AND_AUX_CONCEPT.MD
@@ -130,61 +130,20 @@ Modern smoke units often have a heating element and a separate fan. This require
 
 ## 5. Function Mapping System
 
-The function mapping system connects the triggers (function keys, decoder state) to the logical functions. This system needs to be extremely flexible to accommodate the diverse operational schemes model railroaders use.
+The function mapping system connects user inputs (triggers) to the logical functions. The architecture is designed to be extremely powerful internally, while providing a standardized and user-friendly configuration interface.
 
-### 5.1. Mapping Table Concept
+### 5.1. Internal Architecture: Multi-Level Table Logic
 
-The core of the system is a **Mapping Table**. Each row in the table defines a rule that activates a logical function. The decoder continuously evaluates this table.
+The core of the decoder's mapping capability is a powerful and flexible "Multi-level Table Logic" engine. This system uses a set of user-defined "condition variables" (based on function key states, direction, speed, etc.) and a logic table that can evaluate complex boolean expressions (AND/OR/NOT) on these conditions to activate logical functions. This architecture provides the power needed for state-of-the-art features, far exceeding the capabilities of simple mapping systems.
 
-A single mapping table row would contain:
-- **Conditions**: A set of one or more conditions that must be true for the rule to be active.
-- **Target Logical Function**: The logical function to activate.
-- **Action**: What to do to the logical function (e.g., `TURN_ON`, `SET_BRIGHTNESS`, `TRIGGER_SERVO`).
+### 5.2. User Configuration: RCN-227 Standard
 
-### 5.2. Conditions
+While the internal engine is proprietary, the user-facing configuration will be implemented via the **RCN-227 standard for Extended Function Mapping**. This approach provides the best of both worlds:
 
-Conditions are the building blocks of the mapping logic.
+*   **Standardization & Compatibility**: Users can configure the decoder using familiar methods and tools (like JMRI) that support the RCN-227 standard.
+*   **Power & Flexibility**: The firmware will translate the standardized RCN-227 CVs into the more powerful rules for the internal engine, unlocking the full potential of the hardware and effects system.
 
-- **Function Key State**: `F_STATE(_key_, _state_)` (e.g., `F_STATE(1, ON)`, `F_STATE(5, OFF)`).
-- **Direction**: `DIRECTION_IS(_dir_)` (e.g., `DIRECTION_IS(FWD)`, `DIRECTION_IS(REV)`).
-- **Speed**: `SPEED_IS(_comparison_, _value_)` (e.g., `SPEED_IS(ZERO)`, `SPEED_IS(GT, 0)` for "is moving").
-- **Output State**: `LOGICAL_FUNC_STATE(_func_, _state_)` (e.g., check if another function is already active).
-
-### 5.3. Variants for Mapping Logic
-
-#### Variant A: Simple "AND" Logic (NMRA Style)
-
-This is the traditional approach, similar to the NMRA's extended function mapping CVs. Each mapping rule is a simple AND combination of conditions.
-
-*Example*: Activate "Front Headlight" IF `F0 is ON` AND `Direction is FWD`.
-*Pros*: Simple to understand and configure via CVs.
-*Cons*: Not very flexible. Cannot easily create "OR" logic or more complex scenarios.
-
-#### Variant B: Scripted Logic (Advanced)
-
-This approach uses a simple scripting language (like Lua) or a custom bytecode interpreter. The user could write small scripts to define the logic.
-
-*Example*: `if f_state(0) == ON and direction() == FWD then set_func("Front Headlight", ON) end`
-*Pros*: Extremely powerful and flexible.
-*Cons*: Very complex to implement and potentially difficult for non-technical users to configure. Overkill for most use cases.
-
-#### Variant C: Multi-level Table Logic (Proposed)
-
-This is a hybrid approach that offers a good balance of power and usability. It uses a set of "condition variables" and a final logic table.
-
-1.  **Condition Variables (CVs)**: The user first defines a set of boolean "condition variables" based on the basic triggers. For example:
-    - `C1 = F_STATE(1, ON)`
-    - `C2 = DIRECTION_IS(FWD)`
-    - `C3 = SPEED_IS(GT, 0)`
-2.  **Logic Table**: The mapping table then uses boolean logic on these condition variables.
-    - `IF (C1 AND C2 AND NOT C3) THEN Activate "Yard Mode Light"`
-
-*Pros*: Far more flexible than Variant A. Can create complex AND/OR/NOT logic. Still configurable via a structured table (CVs or a GUI). Avoids the complexity of full scripting.
-*Cons*: Requires more configuration steps than Variant A.
-
-### 5.4. Final Proposal
-
-**Variant C is the clear winner.** It provides the power needed for state-of-the-art features without introducing the steep learning curve of a scripting language. This system would be configured as a series of CVs representing the condition definitions and the final logic table entries.
+As defined in RCN-225 and RCN-227, the user can select the active mapping system using CV 96. This will allow switching between basic NMRA mapping, the various RCN-227 systems, and potentially a "native" mode to directly access the advanced internal engine in the future.
 
 ## 6. Protocol-Specific Considerations
 
@@ -194,7 +153,7 @@ The decoder is intended to be multi-protocol. While the core logic of the effect
 
 The DCC standard is very flexible and is the primary target for this feature set.
 - **Functions**: DCC supports a large number of functions (F0-F28 or even higher, depending on the command station). All these function keys can be used as triggers in the mapping table.
-- **Configuration**: Configuration is typically done via Configuration Variables (CVs). The proposed mapping system (Variant C) can be implemented entirely through CVs. A future PC-based configuration tool could also be used to provide a more user-friendly interface.
+- **Configuration**: Configuration is typically done via Configuration Variables (CVs). The RCN-227 standard provides a comprehensive and compatible method for this.
 
 ### 6.2. Märklin-Motorola (MM)
 
@@ -208,42 +167,52 @@ The MM protocol is older and more limited.
   - The powerful mapping table allows a single MM function key to have different effects based on direction or speed, partially compensating for the limited number of keys.
 - **Configuration**: Configuration on MM-only systems is more challenging. The initial setup would likely require a DCC system to write the CVs. For users without access to DCC, a simplified, pre-configured "personality" could be selected via a single CV.
 
-## 7. Proposed Implementation Roadmap
+## 7. RCN-227 Implementation Roadmap
 
-To make this large project manageable, a phased implementation is recommended.
+To manage the complexity of this feature, a phased implementation is planned. This will allow for incremental development and testing, reducing risk and ensuring a robust final product.
 
-### Phase 1: Core Infrastructure
+### Phase 1: Core Infrastructure & RCN-225
 
-- **Goal**: Establish the foundational software components.
+- **Goal**: Refactor the existing mapping system to support the new architecture and implement the baseline RCN-225 standard.
 - **Tasks**:
-  1. Implement the core classes for Physical Outputs and Logical Functions.
-  2. Implement the `LightEffect` base class and the simplest effects: `Steady` and `Dimming`.
-  3. Implement a basic, direct mapping system (a simplified version of Variant A) to allow F-keys to turn logical functions on and off.
-- **Outcome**: A working system with basic, remappable function outputs.
+  1.  **Refactor `CVLoader`**: Modify the `CVLoader` to read and parse the CVs required for RCN-225 (CVs 33-46 and CV 96).
+  2.  **Refactor `FunctionManager`**: Update the `FunctionManager` to accept mapping rules from the `CVLoader` and populate its internal "Multi-level Table Logic" engine.
+  3.  **Implement RCN-225 Logic**: Implement the basic direction-dependent function mapping as described in RCN-225.
+  4.  **Unit Tests**: Create a suite of unit tests to verify the RCN-225 implementation.
+- **Outcome**: A decoder that correctly implements the standard NMRA/RCN-225 function mapping, with the underlying architecture ready for RCN-227.
 
-### Phase 2: Advanced Effects & Mapping
+### Phase 2: RCN-227 - System per Function
 
-- **Goal**: Implement the full power of the proposed mapping system and lighting effects.
+- **Goal**: Implement the first of the advanced RCN-227 mapping systems.
 - **Tasks**:
-  1. Implement the full, multi-level table logic for function mapping (Variant C).
-  2. Implement all remaining advanced lighting effects (Flicker, Strobe, Mars Light, etc.).
-  3. Develop a comprehensive CV table to configure all new features.
-- **Outcome**: A decoder with state-of-the-art lighting capabilities.
+  1.  **Update `CVLoader`**: Extend `CVLoader` to handle the indexed CV access (via CV 31/32) and parse the "per function" mapping table (CV 32 = 40).
+  2.  **Implement Mapping Logic**: Add the logic to the `FunctionManager` to translate the RCN-227 "per function" bitmask into the internal rule set. This includes handling the "blocking" function logic.
+  3.  **Unit Tests**: Write specific unit tests to verify the "per function" mapping, including various bitmask combinations and the blocking functionality.
+- **Outcome**: The decoder now supports the RCN-227 "per function" mapping system, selectable via CV 96.
 
-### Phase 3: Auxiliary Functions
+### Phase 3: RCN-227 - System per Output (Versions 1 & 2)
 
-- **Goal**: Add support for non-lighting hardware.
+- **Goal**: Implement the simpler "per output" mapping systems.
 - **Tasks**:
-  1. Implement the `SERVO_CONTROL` effect.
-  2. Implement the `SMOKE_GENERATOR` effect, including speed-synchronized fan control.
-  3. Add CVs for configuring these new auxiliary functions.
-- **Outcome**: A full-featured decoder capable of handling complex animations and smoke effects.
+  1.  **Update `CVLoader`**: Extend `CVLoader` to parse the "per output" Version 1 (Matrix) and Version 2 (Function Number) tables (CV 32 = 41 and 42).
+  2.  **Implement V1 Logic**: Add logic to translate the V1 "Matrix" bitmasks for each output into the internal rule set.
+  3.  **Implement V2 Logic**: Add logic to translate the V2 "Function Number" lists (including the "disable" function) into the internal rule set.
+  4.  **Unit Tests**: Create comprehensive unit tests for both V1 and V2, covering various function combinations and the V2 disabling logic.
+- **Outcome**: The decoder now supports two additional RCN-227 mapping modes.
 
-### Phase 4: Tooling & Refinement
+### Phase 4: RCN-227 - System per Output (Version 3)
 
-- **Goal**: Improve user-friendliness and long-term maintainability.
+- **Goal**: Implement the most powerful and complex RCN-227 mapping system.
 - **Tasks**:
-  1. Develop a PC-based configuration tool to simplify the CV programming process.
-  2. Write comprehensive user documentation for all features.
-  3. Refine and optimize the code based on community feedback.
+  1.  **Update `CVLoader`**: Extend `CVLoader` to parse the "per output" Version 3 (Function or Binary State Number) table (CV 32 = 43).
+  2.  **Implement V3 Logic**: This is the most complex step. Implement the logic to handle direction-dependent functions, blocking functions, and the combined function/binary-state numbers. This will map directly to the most powerful features of the internal engine.
+  3.  **Unit Tests**: Develop an extensive set of unit tests for V3, covering all directional dependencies, blocking conditions, and complex scenarios described in the RCN-227 examples.
+- **Outcome**: The decoder now fully implements the RCN-227 standard.
+
+### Phase 5: Tooling & Documentation
+
+- **Goal**: Improve user-friendliness and finalize documentation.
+- **Tasks**:
+  1.  **JMRI Definition File**: Create or update a JMRI decoder definition XML file to provide a user-friendly GUI for configuring all the new RCN-227 CVs.
+  2.  **User Manual**: Write comprehensive user documentation explaining how to use the new function mapping capabilities.
 - **Outcome**: A mature, easy-to-use, and well-documented decoder framework.

--- a/docs/RCN-200.EN.MD
+++ b/docs/RCN-200.EN.MD
@@ -1,0 +1,293 @@
+# RCN-200
+
+## Multi-Protocol Operation
+
+```
+Behavior of Decoders and Command Stations
+```
+```
+Date of Issue
+16.08.2020
+```
+```
+RailCommunity – Association
+of Digital Model Railroad
+Product Manufacturers
+```
+## Contents
+
+1 General ............................................................................................................................. 1
+
+```
+1.1 Purpose of the Standard ........................................................................................................... 1
+1.2 Requirements for Decoders ........................................................................................... 2
+1.3 Requirements for Command Stations ......................................................................................... 2
+```
+2 Defining the Protocol for Accessory Decoders ................................................................... 2
+
+3 Power-On Behavior of Mobile Decoders .............................................................................. 3
+
+4 Digital Operating Modes of Mobile Decoders ........................................................................ 3
+
+```
+4.1 Protocol Detection ............................................................................................. 3
+4.2 Protocol Selection at Startup ............................................................................... 3
+4.3 Protocol Selection During Operation ............................................................................... 4
+4.4 Multiple Addresses ......................................................................................................... 4
+```
+5 Analog Operating Modes ............................................................................................................. 4
+
+6 Transitions Between Operating Modes .................................................................................. 5
+
+7 Multi-Protocol Operation of Command Stations ....................................................................................... 5
+
+Appendix A: References to other Standards .................................................................................. 6
+
+```
+A.1 Normative References .................................................................................................... 6
+A.2 Informative References ................................................................................................... 6
+```
+Appendix B: History ..................................................................................................................... 6
+
+## 1 General
+
+### 1.1 Purpose of the Standard
+
+Many command stations support multiple protocols and transmit them interleaved in time.
+Every decoder should exhibit a clear,
+predictable behavior in such a multi-protocol environment. This is especially true if it supports several of the
+protocols sent by the command station.
+
+Furthermore, the transition to an analog (i.e., not controlled by a digital protocol)
+operating mode must follow fixed rules. This part is a significantly expanded version
+of the corresponding section in [S-9.2.4] of the NMRA.
+
+This standard specifies how a decoder selects its operating mode. Within this standard,
+the term "operating mode" includes all digital protocols and analog operating modes of a
+decoder.
+
+This standard does not define the conditions for detecting a protocol, how a decoder
+is addressed within a protocol, and how to switch between
+different modes within a protocol – e.g., operating mode and programming mode.
+These specifications are defined in the standards for the respective protocols.
+
+### 1.2 Requirements for Decoders
+
+Every decoder must meet all the following requirements. Exceptions are indicated by
+"should" or "may".
+
+A decoder may support multiple protocols and analog operating modes. It is permissible
+to configure a different address for each protocol.
+
+For protocols with block-wise addressing like Selectrix, it cannot be reliably determined
+whether the decoder has been addressed. Therefore, priorities for the supported
+protocols and operating modes are necessary here, which must be clearly described in the manual.
+
+Supported protocols and operating modes can be disabled through configuration.
+For the DCC protocol, CV 12, as defined in [RCN-225], is intended for this purpose. If a
+protocol or operating mode is disabled, a decoder must not react to this protocol or switch to this operating mode, regardless of the following
+stipulations. However, if a disabled but supported digital protocol is detected, the decoder must not switch to
+an analog operating mode.
+
+An exception is packets for programming modes, which may be processed even if the associated
+protocol is disabled. This is necessary because not all protocols have the
+configuration options to re-enable the respective protocol.
+
+### 1.3 Requirements for Command Stations
+
+Every command station must meet all the following requirements. Exceptions are indicated by
+"should" or "may".
+
+## 2 Defining the Protocol for Accessory Decoders
+
+An accessory decoder must always respond to all enabled protocols on all configured
+addresses.
+
+For a fixed selection of the protocol, the problem is that accessory decoders are not
+addressed regularly. Therefore, no selection is generally provided;
+instead, they always react to all enabled protocols.
+
+## 3 Power-On Behavior of Mobile Decoders
+
+When decoders receive power, there are two possibilities:
+
+1.  The powerless state was brief, so the decoder still has valid information
+    about speed, direction, and the last operating mode. In this case, it may immediately
+    resume the previous operation. If the protocol on the track has changed,
+    it must treat this change as if there had been no interruption of the
+    power supply.
+2.  The decoder no longer has complete information about the previous
+    operating state. In this case, the decoder must comply with the corresponding specifications in [RCN-530] and
+    for the DCC programming mode [RCN-216].
+
+If the decoder remembers its operating state in non-volatile memory, so that it
+still knows its old operating state even after a long time, it must have another
+device to detect longer power failures and must not use the old
+operating state afterwards.
+
+## 4 Digital Operating Modes of Mobile Decoders
+
+### 4.1 Protocol Detection
+
+For protocol detection, the following
+standards must be adhered to, depending on the supported protocols: For DCC [RCN-210], [RCN-211], and [RCN-216] for the
+programming mode and, once defined, for mfx® [RCN-245], for Märklin Motorola [RCN-
+265], and for Selectrix [RCN-275]. When detecting a protocol, the correctness
+of the checksum does not need to be verified.
+
+### 4.2 Protocol Selection at Startup
+
+If only one protocol is enabled, the decoder only responds to this protocol and switches
+to this operating mode immediately upon detecting the protocol. This applies in particular to the
+Selectrix protocol, where the decoder would otherwise have to wait to see if it is
+addressed by other means.
+
+If more than one protocol is enabled and a preferred protocol is configured, it should
+always select this protocol as soon as it detects it, regardless of whether
+it is addressed via this protocol.
+
+If the preferred protocol is not detected within a time specified by the manufacturer or user,
+the decoder should behave as if no preferred protocol were set.
+
+If no preferred protocol is set, it should respond to the protocol through which it is
+first addressed. An exception is the Selectrix protocol, as all
+available 112 addresses are always addressed. The decoder should only select the Selectrix protocol
+if it is not addressed by another enabled
+protocol for at least 10 seconds.
+
+As long as it is not addressed by any protocol, the decoder must not activate any output
+and must not turn on the motor.
+
+### 4.3 Protocol Selection During Operation
+
+A decoder may only switch from the selected protocol to another protocol
+if it has not been addressed via the selected protocol for a time specified by the manufacturer or user,
+or if the selected protocol is no longer
+detected. In this case, the operating mode is selected as it would be after applying
+power. The manufacturer can define the time to be arbitrarily short to allow a spontaneous switch
+between protocols. This must be clearly described in the manual.
+
+### 4.4 Multiple Addresses
+
+If a decoder can respond to multiple addresses of a protocol, there must be
+priorities or assignments for them. Separate specifications may be set for each function (motor,
+function outputs, sounds, etc.) of the decoder.
+A single function of a decoder may only be controlled by one address at a time.
+The same rules apply to switching between addresses as to selecting the
+protocol.
+
+An example of assigning functions to addresses is the advanced consisting in the
+DCC protocol. Drive commands are exclusively received on the consist address,
+function commands may be configured to be received on the base or consist address, and
+configuration commands are generally only received on the base address.
+
+## 5 Analog Operating Modes
+
+If a decoder supports an analog operating mode, it must be possible to disable it via a configuration.
+
+The selection of an analog operating mode may only occur if none of the supported
+protocols are detected. In addition, either
+
+*   a DC voltage without polarity change should be detected for at least 200 ms – or the "Maximum time without
+    data reception" set via CV 11 – or
+*   an AC voltage with polarity changes every 7 to 12 ms should be detected.
+
+If these requirements were met and the decoder is in an analog operating mode, it may
+only activate functions, if DCC is supported, that are enabled in CVs 13 and 14 (see
+[RCN-225]) and other manufacturer-specific CVs for functions above F12.
+This setting may also be used for other protocols.
+
+In analog mode, the decoder must immediately exit the analog operating mode upon detecting a
+protocol supported by the decoder. This also applies if the protocol is
+supported by the decoder but is not enabled.
+
+If neither a supported and enabled protocol nor one of the mentioned analog
+voltage forms is detected, the decoder must switch off all consumers
+connected to it.
+
+## 6 Transitions Between Operating Modes
+
+In principle, sharp speed jumps and
+spontaneous changes of direction should be avoided when changing the operating mode. For this purpose, the following rules are established.
+
+If the decoder switches to a (different) digital operating mode, it must maintain the previous
+speed and direction as well as the previous function status until it
+receives corresponding commands in the new operating mode.
+
+If, when changing the operating mode including a change of protocol, the
+direction of travel specified by the new operating mode matches the previous one, the decoder
+must adjust the speed with the start-up or braking delay configured for the new operating mode
+– in analog mode, as far as this is possible given the available
+voltage.
+
+If, when changing the operating mode including a change of protocol, the
+direction of travel specified by the new operating mode does not match the previous one, the
+speed is determined by the new operating mode, but the decoder must maintain the previous
+direction of travel until the vehicle comes to a stop in digital mode through a corresponding
+command or in analog mode by reducing the voltage. After that,
+it must again observe the direction information of the new operating mode. Otherwise, the
+behavior specified for a matching direction of travel applies.
+
+## 7 Multi-Protocol Operation of Command Stations
+
+The command station must ensure that all specifications for all transmitted
+protocols are always met. This particularly affects the minimum repetition rates.
+This may limit the number of simultaneously transmitted protocols.
+
+A vehicle address may only ever be addressed via one protocol. An
+exception is the Selectrix protocol, where the addresses cannot be addressed individually.
+Here, it is the responsibility of the decoder to select the protocol according to section 4.
+
+Each active vehicle address must be addressed at least every 2.5 seconds. A
+vehicle address is considered active if the speed is not 0 or if the
+status in the command station is kept active for other reasons.
+
+If commands for a programming mode are generated, only commands of this protocol
+may be sent. If, for example, the DCC programming mode is
+initiated with DCC reset packets, no other protocols may be sent until the programming is complete.
+Commands for programming on the main track are not affected by this provision,
+i.e., they may also be sent in a multi-protocol environment.
+
+Accessory decoders always respond to all enabled protocols. Therefore, each
+accessory decoder address should only be addressed in one protocol to avoid interference.
+
+## Appendix A: References to other Standards
+
+### A.1 Normative References
+
+The standards listed here must be adhered to for all supported protocols to comply with this
+standard.
+
+[RCN-210] RCN-210 DCC Bit Transmission
+
+[RCN-211] RCN-211 DCC Packet Structure and Address Ranges
+
+[RCN-216] RCN-216 DCC Programming Environment
+
+[RCN-245] RCN-245 mfx/M4 Transitions of Operating Modes 1
+
+[RCN-265] RCN-265 Motorola Transitions of Operating Modes 1
+
+[RCN-275] RCN-275 Selectrix Transitions of Operating Modes 1
+
+[RCN-530] RCN-530 Inrush Current – Track Signal Amplifier - Decoder - Buffer
+
+### A.2 Informative References
+
+The standards and documents listed here are for informational purposes only and are
+not part of this standard.
+
+[RCN-225] RCN-225 DCC Configuration Variables
+
+[S-9.2.4] NMRA: S-9.2.4 DCC Fail Safe
+
+## Appendix B: History
+
+```
+Date Chapter Changes since the previous version
+```
+16.08.2020 All First version
+
+Copyright 2020 RailCommunity – Association of Digital Model Railroad Product Manufacturers e.V.
+
+(^1) This standard does not exist yet or is in preparation. As soon as this standard exists, it will be considered normative.

--- a/docs/RCN-225.EN.MD
+++ b/docs/RCN-225.EN.MD
@@ -1,0 +1,866 @@
+# RCN-225
+
+## DCC Protocol
+
+```
+Configuration Variables
+```
+```
+Date of Issue
+27.07.2025
+```
+```
+RailCommunity – Association
+of Digital Model Railroad
+Product Manufacturers
+```
+## Contents
+
+```
+1 General .......................................................................................................................... 1
+1.1 Purpose of the Standard ........................................................................................................... 1
+1.2 Requirements and Definitions .................................................................................. 1
+2 CV Table for Mobile Decoders ......................................................................................... 2
+2.1 Description of CVs for Mobile Decoders ................................................................ 4
+3 CV Table for Accessory Decoders ......................................................................................... 15
+3.1 Description of CVs for Accessory Decoders ............................................................... 16
+4 CV Table for SUSI Modules ............................................................................................. 18
+Appendix A: References to other Standards .............................................................................. 19
+A.1 Normative References .................................................................................................. 19
+A.2 Informative References ................................................................................................. 19
+Appendix B: History ................................................................................................................ 19
+```
+
+## 1 General
+
+### 1.1 Purpose of the Standard
+
+This standard defines the assignment and use of Configuration Variables (CVs) in
+decoders. CVs make it possible to adapt a decoder to any vehicle or to other mobile or
+stationary objects. Unless otherwise specified, CVs must be stored permanently
+and must not change, even if the power supply is switched off for a
+longer period.
+
+### 1.2 Requirements and Definitions
+
+To comply with this standard, the following conditions must be met.
+
+Supported CVs must be used in the version specified here. The following applies:
+
+*   Mandatory CVs (M) must be supported by every decoder.
+*   Recommended CVs (R) should be supported by every decoder.
+*   Optional CVs can be supported by decoders.
+*   Value unchangeable: This CV is set by the manufacturer and is not
+    changeable. See [RCN-226] for write commands to these CVs.
+*   Range: Specified value ranges must be adhered to.
+*   Bitwise: This CV is composed of up to 8 individual bit values.
+*   Reserved: These CVs are reserved for future extensions of the standard.
+*   Dynamic: These CVs can be changed by the decoder without being requested.
+*   Manufacturer-specific: These CVs can be freely assigned by the manufacturer.
+*   User-specific: These CVs can be freely assigned by the user.
+
+In the "Range" column – more precisely "Value range defined" – either the permissible
+value range (in DCC operation) is specified or it is marked with a "Yes" that there is a
+uniform definition of the values of this CV that must be adhered to.
+
+## 2 CV Table for Mobile Decoders
+
+```
+CV No. CV Usage Type Range Comment
+1 Primary Address M Yes Default value 3
+2 Start Voltage M
+3 Acceleration Rate M
+4 Braking Rate M
+5 Maximum Speed M
+6 Mid-Range Speed O
+7 Decoder Version Number M Value unchangeable^1;
+                                assigned by the manufacturer
+8 Manufacturer ID M Yes Value unchangeable^1;
+                                specified by NMRA
+9 PWM Period O
+10 Manufacturer-specific CV O
+11 Maximum time without data reception R
+12 Permissible Operating Modes O Yes Bitwise
+13 Function Status Alternative
+   Operating Mode F1-F8 O Yes Bitwise
+14 Function Status Alternative
+   Operating Mode F0 + F9-F12 O Yes Bitwise
+15–16 Decoder Lock O Yes
+17–18 Extended Address M Yes Default value 1000
+19 Consist Address R Yes
+20 long consist address. O Yes
+21 Function Control in a
+   Consist F1-F8 O Yes Bitwise
+```
+(^1) Write commands to this CV trigger special functions according to [RCN-226]
+```
+22 Function Control in a
+   Consist F0, F9-F28 O Yes Bitwise
+23 Acceleration Adjustment O Yes
+24 Braking Adjustment O Yes
+25 Speed Table O Yes
+26 n/a - Reserved NMRA
+27 Configuration for Automatic
+   Stopping O Yes Bitwise
+28 Configuration of Two-Way
+   Communication (RailCom) O Yes Bitwise
+29 Decoder Configuration M Yes Bitwise
+30 Error Information O Yes Dynamic value;
+                                0 = no error
+31 Index Value for Extended
+   Range, High Byte O Yes Pointer for CV 257–512
+32 Index Value for Extended
+   Range, Low Byte O Yes Pointer for CV 257–512
+33–46 Function Mapping for F0-F12 O Yes
+47–64 Manufacturer-specific CVs O
+65 Manufacturer-specific CV O
+66 Forward Trim O
+67–94 Speed Table O
+95 Reverse Trim O
+96 Method for Function Mapping O Yes See also [RCN-227]
+97–104 Manufacturer-specific CVs O
+105–106 User ID 1 & 2 O User-specific
+107–108 12-bit Extended
+          Manufacturer ID (M) Only if CV 8 = 238,
+                                otherwise manufacturer-specific
+109–111 Manufacturer-specific CVs O
+112–256 Manufacturer-specific CVs O
+257–512 Extended CV Range O Addressed through
+                                CV 31 and 32
+513–768 Manufacturer-specific CVs -
+769–896 n/a - Reserved NMRA
+897–1024 SUSI-CVs O Yes Reserved for SUSI
+```
+
+### 2.1 Description of CVs for Mobile Decoders
+
+**CV1 Primary Address**
+Bits 0-6 contain the DCC address with a value from 1 to 127 inclusive. Bit 7 must
+have the value 0. For the use of protocols other than DCC, any values are
+permissible. If the value of CV 1 = 0 or >127 and CV 29 Bit 5 = 0, then the DCC
+protocol is disabled. This configuration has no effect on the decoder's ability to respond to
+programming commands. The default value is 3 if the decoder is not
+pre-programmed for a specific vehicle.
+
+**CV 2 Start Voltage**
+The minimum speed is used to define the speed at speed step 1
+at which the motor begins to turn. If the starting voltage is zero volts,
+then there should be no voltage at the motor. If the value is 255, then the full
+DC voltage is at the motor.
+
+**CV 3 Acceleration Rate**
+CV 3 determines the acceleration factor. The formula for the acceleration should
+be equal to the content of (CV 3 * 0.896) / (number of speed steps). E.g.: The content of
+CV 3 is 2. The acceleration is then 0.064 sec / speed step for a decoder with 28
+speed steps. If the value of CV 3 is zero, then there is no programmed acceleration.
+
+However, a decoder can also be configured for other formulas.
+
+**CV 4 Braking Rate**
+CV 4 determines the factor for braking in the same way as described for CV 3.
+
+**CV 5 Maximum Speed**
+CV 5 determines the maximum motor voltage that is present at the highest speed step as a proportion
+of the rectified voltage. If the value is 255, then the full
+DC voltage is supplied at the highest speed step. If the value is 0 or 1, then the
+maximum speed is not used in the calculation of the speed table.
+
+**CV 6 Mid-Range Speed**
+CV 6 determines the motor voltage at half the speed steps as a proportion of the
+rectified voltage. CV 6 is used to create a simple speed curve.
+If the value is 0 or 1, then CV 6 is not used in the calculation of the speed table.
+
+**CV 7 Manufacturer Version Number**
+Shows the manufacturer-defined version of the decoder and its value is not
+changeable. Write commands to CV 7 can – as described in [RCN-226] – also be
+used specifically to configure addressless devices.
+
+**CV 8 Manufacturer ID**
+Must contain the manufacturer ID that was assigned by the NMRA to the manufacturer of the decoder.
+The currently assigned manufacturer IDs can be found in [S-9.2.2 Appendix
+A]. The value in CV 8 is not changeable.
+
+Since the value range of this variable is limited and new manufacturers are added every year,
+an extension is planned. If CV 8 has the value 238 = 0xEE, CVs 107
+and 108 contain an extended 12-bit manufacturer ID.
+
+Write commands to CV 8 can also – as described in [RCN-226] – be used specifically to
+reset the decoder.
+
+**CV 9 PWM Period**
+The value in CV 9 determines the period of the pulse-width modulation at the output of the
+decoder.
+
+**CV 10 Manufacturer-specific CV**
+Was the back-EMF limit in the NMRA, where a value from 1 to 128 inclusive
+determines at which speed step the control of the back-EMF, i.e., the regulation of the
+speed, is switched off.
+
+Due to different usage, it has been released and may be freely used by the decoder manufacturer.
+
+**CV 11 Maximum time without data reception**
+Defines the maximum time period for which the digital operating mode is
+maintained even without data reception. A value of 0 means no maximum time, other values define the
+maximum time, where times up to at least 20 seconds must be adjustable. According to
+[RCN-211] section 5, the maximum time – referred to there as persistence time – must not
+be less than 30 ms.
+
+**CV 12 Permissible Operating Modes**
+This CV defines in which operating modes the decoder may operate.
+
+Bit | Meaning
+--- | ---
+0   | DC (Analog operation DC)
+1   | Radio control
+2   | DCC (Digital operation)
+3   | Selectrix (Digital operation)
+4   | AC (Analog operation AC)
+5   | Motorola (Digital operation)
+6   | mfx (Digital operation)
+7   | reserved for future protocols or operating modes
+
+For all bits, 0 = operating mode disabled, 1 = operating mode enabled. A prioritization
+is not defined by this. How the switch between operating modes occurs is defined in
+[RCN-200].
+
+This configuration has no effect on the decoder's ability to respond to
+programming commands.
+
+The decoder may only switch to an analog operating mode if it is enabled and
+none of the supported digital operating modes are detected. It is irrelevant whether the
+digital operating mode is enabled. In addition, bit 2 in CV 29 must also be
+set for analog operation. If none of the detected digital operating modes are enabled or if no
+digital operating mode is detected and the corresponding analog operating mode is disabled, the
+decoder must switch off all outputs.
+
+**CV 13 Function Status Alternative Operating Mode F1-F8**
+Defines the status for functions F1 to F8 when the decoder is operating in a mode
+in which the corresponding functions cannot be controlled. If a
+function can be controlled, the corresponding bit is ignored. The value 0 of a bit
+indicates that the function is switched off in analog mode, the value 1 means that the
+function is switched on in analog mode. Bit 0 controls F1, bit 7 controls F8.
+
+**CV 14 Function Status Alternative Operating Mode F0, F9-F12**
+Defines the status for functions F0 + F9-F12 when the decoder is operating in a mode
+in which the corresponding functions cannot be controlled. If a
+function can be controlled, the corresponding bit is ignored. The value 0 of a bit
+indicates that the function is switched off in analog mode, the value 1 means that the
+function is switched on in analog mode. Bit 0 controls F0 in the forward direction, bit 1
+controls F0 in the reverse direction, bit 2 controls F9, bit 5 controls F12.
+
+**CV 15 – CV 16 Decoder Lock**
+The decoder lock is used with multiple decoders in one vehicle to change CVs in only
+one of the decoders with the same primary address (CV 1) or extended address (CV 17
+and CV 18). For this, CV 16 must be programmed to a different number in each decoder
+before the decoders are installed in the vehicle. To change or read the value of a
+CV in one of the installed decoders, you program the
+corresponding number in CV 15 and then program the CVs of the selected
+decoder. The decoders compare the values in CV 15 and CV 16 and if both values
+are equal, access to CVs is enabled. If the comparison fails,
+no access to the CVs of this decoder is possible. The lock is independent of whether the
+CVs are accessed in programming mode or in operating mode.
+
+Regardless of the values in CVs 15 and 16, it is always possible to
+write to CV 15. Only an enabled decoder can be reset by writing the value 8 to CV 8.
+CV 16 can also be reset in this process.
+
+The following use of the values in CV 16 is recommended: 1 for motor decoders, 2 for
+sound decoders, 3 or higher for other types of decoders, 0 should not be used in vehicles with
+multiple decoders so that CV 15 = 0 can lock all decoders.
+
+The values 240 to 255 are reserved as commands for special actions. These values are
+not allowed for CV 16. If they are written to CV 15, they are not stored there
+but only trigger a defined action. The following value is defined so far:
+CV 15 = 255: The decoder copies the value from CV 16 to CV 15, i.e., all decoders are
+unlocked. This allows, for example, all decoders to be reprogrammed to the same address.
+It is also possible to unlock a single decoder with an unknown value in CV 16.
+Furthermore, a programming device can determine which values are in
+CV 16 of the individual decoders by querying the values 1 to 239 using single
+byte verify commands according to [RCN-214] [Chapter 2.2], i.e., create a list of the available decoders.
+
+**CV 17 – CV 18 Extended Address**
+CV 17 and CV 18 contain the extended address of the decoder. It is used when
+bit 5 is set in CV 29. CV 17 contains in bits 0 to 5 the 6 higher-order
+bits of the 14-bit address, bits 6 and 7 are always set. Thus, the value
+is always in the range of 11000000 to 11100111 (192 to 231). CV 18 contains the
+lower-order bits of the address and can take the value 0 to 255. The address 0 (CV
+17 = 192 and CV 18 = 0) is not allowed.
+
+The default value is 1000 (CV 17 = 195 = 11000011, CV 18 = 232 = 11101000),
+if the decoder is not pre-programmed for a specific vehicle.
+
+**CV 19 – CV 20 Consist Address**
+If a consist is to be controlled via a 7-bit address according to [RCN-211],
+then CV 19 contains in bits 0 to 6 the seven-bit address for controlling the
+consist. CV 20 has the value 0 (00000000).
+
+If a consist is to be controlled via a 14-bit address according to [RCN-211],
+then CV19 contains in bits 0 to 6 the two lower-order digits of the address in
+decimal notation and CV 20 in bits 0 to 6 the two or three higher-order
+digits of a 4 or 5-digit address in decimal notation. Values above 99 in
+bits 0-6 of CV 19 are not intended in this case, but should be tolerated by the decoder.
+The address is calculated by the decoder by multiplying the value in CV 20, bits 0
+to 6 by 100 and adding it to the address part in CV 19. If the resulting
+address is above 10239, then the vehicle is not part of a consist.
+
+CV 19 bit 7 determines the relative direction within the consist. If the value is 0,
+the vehicle-related direction of travel corresponds to that of the consist. If the value
+is 1, the vehicle-related direction of travel is opposite to that of the consist.
+
+CV 20 bit 7 = 1 designates the corresponding vehicle as the lead locomotive, so that in RailCom
+channel 2 the same data is sent as if the decoder were addressed via its main address
+in CV 1 or CV 17 and 18. This bit should only be set in one
+decoder of the consist. This provides feedback from
+one vehicle within the consist without having to address a decoder individually.
+
+If bits 0-6 of CV 19 have the value 0 (0000000) and the value in CV 20 is 0
+(00000000), then the vehicle is not part of a consist.
+
+**CV 21 Function Control in a Consist F1-F8**
+Defines whether the functions F1-F8 are controlled via the consist address in CV 19 and
+CV 20. For each bit, the value 1 means that the corresponding function
+is only addressed via the consist address. A value of 0 indicates that the
+function is only addressed via the address of the respective vehicle in CV 1 or CV 17 and 18.
+Bit 0 corresponds to F1, bit 7 corresponds to F8.
+
+**CV 22 Function Control in a Consist F0 + F9-F28**
+Defines whether the functions F0 + F9-F28 are controlled via the consist address in CV 19
+and CV 20. For each bit, the value 1 means that the corresponding
+function(s) are only addressed via the consist address. A value of 0 indicates
+that the function(s) are only addressed via the address of the respective vehicle in CV 1 or CV 17
+and 18. Bit 0 corresponds to F0 in the forward direction, bit 1
+corresponds to F0 in the reverse direction, bit 2 corresponds to F9, bit 5 corresponds to F12, bit 6
+simultaneously controls functions F13 to F20 and bit 7 simultaneously controls
+functions F20 to F28. Bits 6 and 7 in CV22 always affect the entire
+function group, in contrast to the individually selectable functions F0 to F12. For this
+reason, there are no separate CVs for F13 to F20 and F21 to F28. The
+support of bits 6 and 7 is optional.
+
+**CV 23 Acceleration Adjustment**
+CV 23 contains an additional factor for acceleration, which according to the formula (content of
+CV 23 * 0.896) / (number of selected speed steps) is added to or
+subtracted from the value in CV 3. The value is seven bits long (bits 0-6), with bit 7 being used as a sign
+(0 = positive, 1 = negative). In case of an overflow, the maximum acceleration
+should be used. In case of an underflow, no acceleration is used. This CV
+is used to simulate different train lengths and train loads. It is often used in the
+consisting of vehicles. This CV can also be changed with the special
+configuration variable access command – short form (see [RCN-214]).
+
+**CV 24 Braking Adjustment**
+CV 24 contains an additional factor for braking, which according to the formula (content of
+CV 24 * 0.896) / (number of selected speed steps) is added to or
+subtracted from the value in CV 4. The value is seven bits long (bits 0-6), with bit 7 being used as a sign
+(0 = positive, 1 = negative). In case of an overflow, the maximum braking should be
+used. In case of an underflow, no braking is used. This CV is used to simulate
+different train lengths and train loads. It is often used in the consisting of
+vehicles. This CV can also be changed with the special configuration variable
+access command – short form (see [RCN-214]).
+
+**CV 25 Speed Tables, Mid-Range Speed**
+A value from 2 to 127 inclusive is used to activate 1 to 126 manufacturer-predefined
+speed tables. The value 2 = 00000010 results in a
+linear curve.
+
+A value from 128 to 154 inclusive defines, relative to 28 speed steps, the speed step
+at which the standard or in CV 6 defined mid-range speed is assumed.
+For 14 speed steps, the decoder divides this value by two; for 128 speed steps, the
+value must be converted accordingly.
+
+For values of 0 and 1 and above 154, this CV has no effect on the effective
+speed table. If bit 4 is set in CV 29, this CV is ineffective.
+
+**CV 27 Configuration for Automatic Stopping**
+CV 27 configures the actions for which the decoder automatically stops the vehicle.
+
+*   Bit 0 = Enable stop on an asymmetric DCC signal, positive on the
+    right rail.
+*   Bit 1 = Enable stop on an asymmetric DCC signal, positive on the left
+    rail.
+*   Bit 2 = Enable stop on a stop signal encoded by gaps in the sync bits
+    (HLU).
+*   Bit 3 = Reserved for future use
+*   Bit 4 = Enable stop on detection of a DC voltage corresponding to driving in the
+    opposite direction.
+*   Bit 5 = Enable stop on detection of a DC voltage corresponding to driving in the
+    same direction.
+*   Bits 6-7 = Reserved for future use
+
+Bit = 0 = disabled and Bit = 1 enabled.
+Note: If the decoder does not support one of these properties, the
+decoder must not allow the corresponding bit to be set.
+
+**CV 28 Configuration of Two-Way Communication (RailCom)**
+
+*   Bit 0 = Enable Channel 1 Address Broadcast
+*   Bit 1 = Enable Channel 2 Data and Acknowledge
+*   Bit 2 = Enable Channel 1 auto-off
+*   Bit 3 = Enable ID 3 in Channel 1
+*   Bit 4 = Enable programming address 0000 (long address 0) (see [RCN-217])
+*   Bit 5 = Reserved for future use
+*   Bit 6 = Enable high-current RailCom
+*   Bit 7 = Enable automatic registration (RCN-218 or RailComPlus®)
+
+Bit = 0 = disabled and Bit = 1 enabled.
+Note: If the decoder does not support one of these properties, the
+decoder must not allow the corresponding bit to be set.
+
+**CV 29 Decoder Configuration**
+
+*   Bit 0 = Direction of the vehicle: 0 = normal, 1 = inverse direction of travel. This bit
+    controls the direction of the vehicle relative to the direction bit in the
+    speed commands or the specification by an applied analog voltage. Direction-
+    related functions such as lighting of the headlights (F0) are
+    also reversed according to the direction of travel of the vehicle.
+*   Bit 1 = Transmission of the light function F0: 0 = F0 is transmitted in bit 4 of the basic
+    speed command (14 speed step mode), 1 = F0 is transmitted in bit 4
+    of the function command F0-F4. Bit 4 in the basic
+    speed command is used as the 5th speed step bit (28 speed step mode).
+*   Bit 2 = Enable analog operation: 0 = digital operation only, 1 = analog operation also
+    possible.
+*   Bit 3 = Enable two-way communication (RailCom): 0 = disabled, 1 = enabled
+*   Bit 4 = Speed table:
+    *   0 = Speed is calculated from CVs 2, 5 + 6.
+    *   1 = Speed is calculated from the table in CVs 67 – 94.
+    It is up to the manufacturer whether CVs 2, 5, and 6 are also used
+    to scale the table in CVs 67-94 when bit 4 is set. This must be clearly
+    defined in the manual.
+*   Bit 5 = Loco address: 0 = primary address from CV 1, 1 = extended address from CV 17 and
+    CV 18.
+    It is up to the manufacturer whether this bit is automatically reset when the short
+    address is written to CV 1. This must be clearly defined in the
+    manual.
+*   Bit 6 = Reserved for future use
+*   Bit 7 = Type of control: 0 = control via commands according to RCN-212
+    (mobile decoder), 1 = control via commands according to RCN-213
+    (accessory decoder).
+
+Note: If the decoder does not support one of these properties, the
+decoder must not allow the corresponding bit to be set.
+
+**CV 30 Error Information**
+If an error situation occurs in the decoder, this CV should contain a manufacturer-defined
+error number. The value 0 means that no error has occurred.
+
+**CV 31 – CV 32 Index Values for Extended Range**
+To expand the usable CVs, the range of CV257 – CV512 was set up for
+block-wise addressing. CV 31 and CV 32 are the pointers to the respective
+block.
+
+CV 31 contains the higher-order bits of the pointer and may have a value from 0 =
+00000000 to 255 = 11111111 inclusive. The values from 0 =
+00000000 to 15 = 00001111 inclusive are for the applications defined below
+as well as for future use reserved (= 4096 blocks). The 61440 blocks accessible via the values
+16 = 00010000 to 255 = 11111111 can be freely used by the
+manufacturers.
+
+CV32 contains the lower-order bits of the pointer and can take any value. If only
+a 256-byte block is required, the CV values for it are to be set fixed and these are only
+to be executed read-only.
+
+The page selected with CV 31 = 0 and CV 32 = 0 corresponds to CVs 1 to 256.
+The page selected with CV 31 = 0 and CV 32 = 1 corresponds to a memory area not otherwise
+accessible. This area corresponds in decoders without indexed
+access via CVs 31 and 32 to the area CVs 257 to 512.
+The page selected with CV 31 = 0 and CV 32 = 2 corresponds to CVs 513 to 768.
+The page selected with CV 31 = 0 and CV 32 = 3 corresponds to CVs 769 to 1024, whereby
+from CV 897 connected SUSI modules are accessed. In this way, all SUSI CVs can be reached
+even with command stations that only allow 3-digit CV numbers.
+
+The pages addressed via CV31 = 0 and CV32 = 40 to 43 are used for function mapping
+according to [RCN-227].
+The page addressed via CV31 = 0 and CV32 = 254 is intended for describing the
+functionalities of decoders. A bit = 1 means that the
+corresponding functionality is supported by the decoder. The page can only be read.
+
+```
+Byte 0 Support for combined speed commands
+Bit 0: Speed, direction and functions (0011-1100)
+       according to [RCN-212] section 2.3.
+Bits 1 to 7 reserved.
+Byte 16 Support for combined programming commands
+Bit 0: Short write command for CV #17 and CV #18 (1111-0100)
+       according to [RCN-214] section 3.
+Bit 1: Short write command for CV #31 and CV #32 (1111-0100)
+       according to [RCN-214] section 3.
+Bits 2 to 7 reserved
+Byte 17 Support for special programming commands
+Bit 0: XPOM according to [RCN-217]
+Bits 1 to 7 reserved
+Byte 33 Bit-mask for possible values in CV96, i.e., which types of
+        function mapping are supported. Bit 0 is always 0, Bit 1 = 1
+        means the value 1 can be set in CV 96, Bit 2 corresponds to
+        value 2, Bit 3 corresponds to value 3, etc. up to Bit 7, which corresponds to value 7.
+        0 to 7 bits can be set.
+```
+
+All remaining bytes are reserved.
+
+The page addressed via CV31 = 0 and CV32 = 255 is reserved for RailCom applications according to
+[RCN-217].
+The pages addressed via CV31 = 1 and CV32 = 0 or 1 are used by RailComPlus®.
+The 256 pages addressed via CV31 = 2 are used for data spaces according to [RCN-218].
+
+Below is a tabular overview of the pages defined so far.
+
+CV 31 | CV 32 | Page
+--- | --- | ---
+0 | 0 | CVs 1 to 256
+0 | 1 | CVs 257 to 512
+0 | 2 | CVs 513 to 768
+0 | 3 | CVs 769 to 1024
+0 | 4 - 39 | reserved
+0 | 40 - 43 | Function mapping according to [RCN-227]
+0 | 44 - 253 | reserved
+0 | 254 | Functionalities of decoders
+0 | 255 | RailCom page according to [RCN-217]
+1 | 0 - 1 | Loco Info RailComPlus®
+1 | 2 - 255 | reserved
+2 | 0 | Data space 0 according to [RCN-218]
+2 | 1 | Data space 1 according to [RCN-218]
+2 | 2 | Data space 2 according to [RCN-218]
+2 | 3 | reserved for systematic reasons
+2 | 4 | Data space 4 according to [RCN-218]
+2 | 5 | Data space 5 according to [RCN-218]
+2 | 6 | Data space 6 according to [RCN-218]
+2 | 7 | Data space 7 according to [RCN-218]
+2 | 8 - 255 | reserved for further data spaces
+3 - 15 | 0 - 255 | reserved
+16 - 255 | 0 - 255 | Manufacturer-specific CVs
+
+The data spaces accessible via CV 31 = 2 according to [RCN-218] are stored without HEADER and
+without length specification, i.e., the first byte of the data space is accessed via CV 257.
+The area not used by the data space should be filled with 0x00.
+
+**CV 33 – CV 46 Function Mapping for F0 to F12**
+The CVs form a matrix for a maximum of 14 decoder outputs. This allows the user to
+assign the received function to one or more outputs for control. A value = 1
+in a bit of these CVs controls the corresponding output. The default setting is that
+F0 controls output 1 (LV) when driving forward and output 2 (LH) when driving backward,
+F1 controls output 3 up to F12 which controls output 14. The LSB is always on the right in the valid
+(white) area. The table shows the default settings of the "1" bits.
+
+The weights of the bits are arranged offset according to the NMRA standard [S-9.2.2],
+so that with CV 38 to 42 functions F4 to F8 can be assigned to outputs 4 to 11
+and with CV 43 to 46 functions 7 to 14 can be assigned.
+For reasons of compatibility, this assignment is retained. For the use of
+functions up to F28 and for any assignment between functions and a maximum of 32
+outputs, reference is made to [RCN-227].
+
+MSB | Output Ax | LSB
+--- | --- | ---
+CV | Description | 14 | 13 | 12 | 11 | 10 | 9 | 8 | 7 | 6 | 5 | 4 | 3 | 2 | 1
+33 | F0 forward | | | | | | | | | | | | | | 1
+34 | F0 reverse | | | | | | | | | | | | | 1 |
+35 | Function 1 | | | | | | | | | | | | 1 | |
+36 | Function 2 | | | | | | | | | | | 1 | | |
+37 | Function 3 | | | | | | | | | | 1 | | | |
+38 | Function 4 | | | | | | | | | 1 | | | | |
+39 | Function 5 | | | | | | | | 1 | | | | | |
+40 | Function 6 | | | | | | | 1 | | | | | | |
+41 | Function 7 | | | | | | 1 | | | | | | | |
+42 | Function 8 | | | | | 1 | | | | | | | | |
+43 | Function 9 | | | | 1 | | | | | | | | | |
+44 | Function 10 | | | 1 | | | | | | | | | | |
+45 | Function 11 | | 1 | | | | | | | | | | | |
+46 | Function 12 | 1 | | | | | | | | | | | | |
+
+**CV 47 – CV 64 Manufacturer-specific CVs**
+This CV range may be freely used by the decoder manufacturer.
+
+**CV 65 Kick Start**
+Was the extent of extra pulses applied to the motor between stop and before the
+first speed step in the NMRA. With today's regulated decoders, this is no longer
+necessary.
+
+Due to different usage, it has been released and may be freely used by the decoder manufacturer.
+
+**CV 66 Forward Trim**
+Contains a scaling with which a motor voltage can be multiplied when the
+decoder drives the vehicle in the forward direction. The scaling is designed as n/128.
+If CV 66 contains the value 0, then no trimming in the forward direction is
+implemented.
+
+**CV 67 – CV 94 Speed Table**
+The speed table consists of 28 bytes and thus of values for 28 speed steps.
+If the decoder is operated with 14 or 128 speed steps, the table must be internally
+adapted by omitting values or by interpolation. The use of this table is
+enabled via bit 4 in CV 29.
+
+**CV 95 Reverse Trim**
+Contains a scaling with which a motor voltage can be multiplied when the
+decoder drives the vehicle in the reverse direction. The scaling is designed as n/128.
+If CV 95 contains the value 0, then no trimming in the reverse direction is
+implemented.
+
+**CV 96 Selection of the Method for Function Mapping**
+Is used to select the method for function mapping. If multiple function mapping systems
+are implemented in a decoder, the user can select the desired system via the
+configuration variable CV 96. If only one system is
+implemented, CV 96 must have the corresponding value. The decoder may only
+accept values when writing to CV 96 that correspond to implemented function mappings.
+Otherwise, the old value must be retained.
+
+Within CV 96, only bits 0 to 2 are used to select the function mapping.
+The other bits are still reserved and must contain a 0.
+
+Value | Meaning
+--- | ---
+0 | Invalid (an unimplemented CV 96 may yield a 0)
+1 | Function mapping via CVs 33 to 46 according to this RCN or [S-9.2.2]
+2 | Function mapping via CVs 257 to 512 in the bank selected by CV 31 = 0 and CV 32 = 40 with CVs per function according to [RCN-227] section 2
+3 | Function mapping via CVs 257 to 512 in the bank selected by CV 31 = 0 and CV 32 = 41 with CVs per output according to [RCN-227] section 3.1
+4 | Function mapping via CVs 257 to 512 in the bank selected by CV 31 = 0 and CV 32 = 42 with CVs per output according to [RCN-227] section 3.2
+5 | Function mapping via CVs 257 to 512 in the bank selected by CV 31 = 0 and CV 32 = 43 with CVs per output according to [RCN-227] section 3.3
+6 | Manufacturer-specific function mapping
+7 | reserved
+
+**CV 97 – CV 104 Manufacturer-specific CVs**
+This CV range is reserved by the NMRA, but has already been used by several manufacturers.
+Therefore, there are no restrictions on these CVs from the RailCommunity and
+they can be freely used by the decoder manufacturer.
+
+**CV 105 – CV 106 User Identification**
+These CVs are reserved for the user. He can store additional vehicle-specific
+data here.
+
+**CV 107 – CV 108 Extended Manufacturer ID / Manufacturer-specific CVs**
+If the "Manufacturer ID" CV 8 contains the value 238 = 0xEE, these two CVs are for
+the extended 12-bit manufacturer ID. The 8 lower-order bits are in
+CV 108 and the 4 higher-order bits are in CV 107 bits 0 to 3. Bits 4 to 7 in CV 107 are
+always 0. For all other values in CV 8, these CVs may be freely used by the decoder manufacturer.
+
+**CV 109 – CV 111 Extended Manufacturer Version Number**
+These three CVs are intended by the NMRA for an extension of the manufacturer version number in
+CV 7. Since the value in CV 7 is manufacturer-dependent and the extension
+will be different for each manufacturer anyway, there are no
+restrictions on these CVs from the RailCommunity and they can be freely used by the
+decoder manufacturer like the following group.
+
+**CV 112 – CV 256 Manufacturer-specific CVs**
+This CV group may be freely used by the decoder manufacturer.
+
+**CV 257 – CV 512 Extended CV Range**
+To expand the usable CVs, the range of CV 257 to CV 512 was set up for
+block-wise addressing. There are 65536 blocks with 256 bytes each available.
+The first 4096 blocks are reserved for future use. The
+freely usable area starts at block 4096. This means that a total of 61,440 indexed blocks are freely
+usable. The blocks are addressed via CV 31 (high address bits) and CV 32
+(low address bits).
+
+**CV 513 – CV 768 Manufacturer-specific**
+This area was originally intended for accessory decoders, but is no longer
+needed for that purpose. Even though many accessory decoders still respond to these CVs, these
+CVs can be used for mobile decoders in a manufacturer-specific way.
+
+**CV 769 – CV 896 Reserved NMRA**
+These CVs are reserved. CVs 892 to 896 were reserved for dynamic values for reading via
+RailCom, but are not needed at the present time. These CVs are marked as reserved until
+a final decision is made.
+
+**CV 897 – CV 1024 SUSI Configuration Variables**
+These CVs are reserved for the SUSI bus module expansion interface and are defined in
+[RCN-602].
+
+## 3 CV Table for Accessory Decoders
+
+In the older versions of NMRA RP-9.2.2, the CV range
+from 513 was intended for accessory decoders. However, since this range is not accessible by all programming devices,
+the accessory decoders ignored the bit with the value 512
+in the CV number. Therefore, NMRA [S-9.2.2] was also adapted and the CVs from CV 1 were defined
+and the CV numbers higher by 512 were marked as optional. These optional CV
+numbers are entered in the second column. The range CV 513 to 895 can be
+used by any manufacturer as desired.
+
+Since the standard addressing via CV 1 and CV 9 does not work for decoders that are to respond to several independent addresses in operating mode,
+these CVs are only listed as optional. In any case, the address of most accessory decoders is
+set via a button.
+
+CV No. | Permissible^2 | CV Usage | Type | Range | Comment
+--- | --- | --- | --- | --- | ---
+1 | 513 | Decoder Address Low Bits | M | 6 or 8 Bit LSB
+2 | 514 | Additional Activation | O | Act. of outputs
+3 | 515 | Time Output 1 Active | O
+4 | 516 | Time Output 2 Active | O
+5 | 517 | Time Output 3 Active | O
+6 | 518 | Time Output 4 Active | O
+7 | 519 | Manufacturer Version Number | M | Value unchangeable^3; assigned by manufacturer
+8 | 520 | Manufacturer ID | M | Yes | Value unchangeable^3; specified by NMRA
+9 | 521 | Decoder Address High Bits | M | 3 Bit MSB
+10–14 | --- | - | Reserved NMRA
+15 & 16 | --- | Decoder Lock | O | Yes
+17 & 18 | --- | Mirrored Address | - | CVs 1 and 9 mirrored
+19–27 | --- | - | Reserved NMRA
+28 | 540 | Configuration of Two-Way Communication (RailCom) | O | Yes | Bitwise
+29 | 541 | Decoder Configuration | R | Yes | Bitwise
+30 | --- | - | Reserved NMRA
+31 & 32 | --- | Index Values for Extended Range | O | Yes | Pointer for CV 257 to 512
+33 | --- | Status of Outputs | O | Yes | RailCom feedback
+34–81 | --- | Manufacturer-specific | O
+82–106 | --- | - | Reserved NMRA
+107–108 | --- | 12-bit Extended Manufacturer ID | (M) | Only if CV 8 = 238, otherwise reserved
+109–111 | --- | - | Reserved NMRA
+112–128 | --- | Manufacturer-specific | O
+129–256 | --- | Manufacturer-specific | O
+257–512 | --- | Extended CV Range | O | Addressed through CV 31 and 32
+513–895 | --- | Manufacturer-specific | O | Freely usable by manufacturer
+
+(^2) Not recommended for new developments
+(^3) Write commands to this CV trigger special functions according to [RCN-226]
+
+### 3.1 Description of CVs for Accessory Decoders
+
+**CV 1 (513) Decoder Address Low Bits**
+CV1 contains the low-order address bits of the decoder. The high-order address bits are stored in
+CV 9. Two types of accessory decoders are supported: addressing the
+decoder and addressing the output. An accessory decoder must support one type
+and optionally the other type. The type of decoder is defined in CV 29, bit 6. If
+CV 1 = 1 and CV 9 = 0, then both types of accessory decoders respond with the
+first output pair to the user address 1 = address 4 in the data packet (see
+[RCN-213]). The type of addressing that is supported must be clearly documented in the manual and
+on the packaging.
+
+1.  Addressing the decoder: CV 1 contains the 6 low-order bits of the 9-bit
+    user address in bits 0 to 5 as in the first byte of the commands for accessory decoders
+    according to [RCN-213]. Bits 6 and 7 have the value 0.
+2.  Addressing an output pair: CV 1 contains the 8 low-order bits of the 11-bit
+    user address in bits 0 to 7. Before comparison with the data packet, the
+    decoder must add 3 to the address set in CVs 1 and 9. Bits 2 to 7
+    then correspond to bits 0 to 5 in the first byte of the commands for accessory decoders
+    according to [RCN-213]; bits 0 and 1 correspond to bits 1 and 2 in the second byte
+    of the commands for accessory decoders according to [RCN-213].
+
+The three most significant bits are stored in CV 9.
+
+If an accessory decoder supports more than one sequential output, the
+stored address corresponds to the value for the first output in the series.
+
+**CV 2 (514) Additional Activation**
+Bits 0 to 7 = additional activation of the outputs: If the corresponding bit for the output
+is 0, then the output is not activatable by an additional input on the decoder.
+If the bit is 1, the output can be activated by an additional input on the decoder.
+
+**CV 3 to 6 (515 to 518) Time Output 1 to 4 Active**
+The time an output is active can be determined by the corresponding configuration variable.
+CV 3 (515) determines the time for output 1 and CV 6 (518) the time
+for output 4. If the value is 0, the output is active permanently or until a switch-off command.
+
+**CV 7 (519) Manufacturer Version Number**
+Corresponds to CV 7 for mobile decoders.
+
+**CV 8 (520) Manufacturer ID**
+Corresponds to CV 8 for mobile decoders.
+
+**CV 9 (521) Decoder Address High Bits**
+CV 9 contains, regardless of the type of addressing described for CV 1, the three
+most significant bits of the user address. These are stored in bits 0 to 2. Bits
+3 to 7 are always 0.
+
+**CV 15 – CV 16 Decoder Lock**
+Corresponds to CVs 15 and 16 for mobile decoders.
+
+**CVs 17 and 18 Mirrored Address**
+Mirror of CVs 1 and 9 for accessory decoders, similar to the CVs for mobile decoders,
+where an output pair is always addressed. Bits 6 and 7 in CV 17 are only
+set if bit 7 in CV 29(541) = 0, i.e., if the accessory decoder is addressed via a mobile
+address. Since accessory decoders only have 11 address bits, if
+bit 7 in CV 29(541) is set, bits 3 to 7 in CV 17 must be 0.
+
+**CV 28 (540) Configuration of Two-Way Communication (RailCom)**
+CV 28 is used to configure the two-way communication of the decoder (RailCom)
+if bit 3 in CV 29 is set.
+
+*   Bit 0 = Reserved for future use
+*   Bit 1 = Enable Channel 2 Data and Acknowledge
+*   Bits 2 - 5 = Reserved for future use
+*   Bit 6 = Enable high-current RailCom
+*   Bit 7 = Enable automatic registration (RCN-218 or RailComPlus®)
+
+Bit = 0 = disabled and Bit = 1 enabled.
+
+Note: If the decoder does not support one of these properties, the
+decoder must not allow the corresponding bit to be set.
+
+**CV 29 (541) Decoder Configuration**
+
+*   Bits 0 - 2 = Reserved for future use
+*   Bit 3 = Enable two-way communication (RailCom):
+    `0 = disabled, 1 = enabled`
+*   Bit 4 = Reserved for future use
+*   Bit 5 = Decoder Type: 0 = Simple Accessory Decoder, 1 = Extended Accessory Decoder
+*   Bit 6 = Method of addressing: 0 = Addressing the decoder,
+    `1 = Addressing the output`
+*   Bit 7 = Type of control:
+    `0 = Control via commands according to [RCN-212] (Mobile Decoder),`
+    `1 = Control via commands according to [RCN-213] (Accessory Decoder)`
+    If bit 7 = 1, then the decoder may only ignore the most significant bit of the CV
+    number during programming. If this
+    property is used, CV 513 becomes CV1, etc. Decoders that use this conversion
+    must clearly document this in the manual.
+
+Note: If the decoder does not support one of these properties, the
+decoder must not allow the corresponding bit to be set.
+
+**CVs 31 and 32 Index Values for Extended Range**
+Corresponds to CVs 31 and 32 for mobile decoders.
+
+**CVs 33 Status of the Decoder's Outputs**
+This CV contains the status of all four output pairs of simple accessory decoders. It
+can be used to query the status via RailCom. The assignment of the outputs to
+the bits in CV 33 is as follows:
+
+Output Pair | 4 | 3 | 2 | 1
+--- | --- | --- | --- | ---
+R-Bit in command to select this output (button color) | 0 (R) | 1 (G) | 0 (R) | 1 (G) | 0 (R) | 1 (G) | 0 (R) | 1 (G)
+Bit in CV 33 | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0
+
+According to [RCN-213], in the command for simple accessory decoders, R = 0 means turnout to
+diverging or direction left or signal to stop (traditionally the red button) and R = 1
+means turnout straight or direction right or signal to proceed (traditionally the green button).
+
+**CV 107 – CV 108 Extended Manufacturer ID / Manufacturer-specific CVs**
+Corresponds to CVs 107 and 108 for mobile decoders.
+
+## 4 CV Table for SUSI Modules
+
+The CVs for the SUSI range CV 897 to CV 1024 are documented in [RCN-602].
+
+## Appendix A: References to other Standards
+
+### A.1 Normative References
+
+No other standards need to be adhered to in order to comply with this standard.
+
+### A.2 Informative References
+
+The standards and documents listed here are for informational purposes only and are
+not part of this standard.
+
+[RCN-200] RCN-200 Multi-Protocol Operation Behavior of Decoders and Command Stations
+[RCN-211] RCN-211 DCC Packet Structure, Address Ranges and Global Commands
+[RCN-212] RCN-212 DCC Operating Commands for Mobile Decoders
+[RCN-213] RCN-213 DCC Operating Commands for Accessory Decoders
+[RCN-214] RCN-214 DCC Configuration Commands
+[RCN-217] RCN-217 RailCom – DCC Feedback Protocol
+[RCN-218] RCN-218 DCC-A – Automatic Registration
+[RCN-226] RCN-226 DCC Special Values for Configuration
+[RCN-227] RCN-227 DCC Extended Function Mapping
+[RCN-602] RCN-602 SUSI-Bus Configuration Variables
+[S-9.2.2] NMRA: S-9.2.2 DCC Configuration Variables
+[S-9.2.2 Appendix A] NMRA: S-9.2.2 Appendix A DCC Manufacturer ID codes
+
+## Appendix B: History
+
+Date | Chapter | Changes compared to the previous version
+--- | --- | ---
+27.07.2025 | 2.1 | Addition of Bit 7 in CV 20. CV 28 Bit 4 Programming address changed from 0003 to 0000. Definition of how data spaces according to [RCN-218] are stored in the pages selected via CVs 31 and 32.
+21.07.2023 | 2.1 / 3.1 | Minor corrections in the section for CVs 15 and 16. CV 28 Bit 3 added to enable ID 3 in Channel 1. SUSI modules are also reached via CV 31 = 0, CV 32 = 3. The page selected via CV 31 = 2, CV 32 = 3 is now marked as reserved. CV 33 for the status of the outputs for feedback via RailCom.
+26.11.2022 | 2.1 / 2.2 / 3.1 | CVs 513–768 now manufacturer-specific. Definition of CV 20 for long consist address. CVs 21 and 22: Functions never react simultaneously to primary and consist address. Extension of CV 22 for functions F13 to F28. Definition of the bits in CVs 107 and 108. Same values in CV 1 & 9 for user address 1 (as in [RCN-213]).
+23.07.2022 | 2.1–3.1 | The following CVs have been marked as mandatory (M): 2, 3, 4, 5, 17 and 18. CV 7 and 8 now "Value unchangeable" instead of "Read Only". Manufacturer ID instead of Manufacturer Identification. CV 12 text adapted, as in future in accordance with the NMRA. Extended text for CVs 15 and 16 and CV 15 = 255 to unlock all decoders. 12 (instead of 16) bit manufacturer ID in CVs 107 and 108. Further specification for CVs 15 and 16. Addition of the SUSI Configuration Variables (reference to [RCN-602]). CVs 15, 16, 107 and 108 also for accessory decoders.
+31.06.2021 | 2.1 / 3.1 | Addition of data spaces for [RCN-218] up to data space 7. Some CVs for accessory decoders no longer mandatory. CVs from 513 as mirrored CVs from 1 only "permissible".
+12.12.2020 | 2.1 | Assignments of the indexed pages supplemented and summarized in a table.
+10.05.2019 | 3.1 | Bits 0 and 2 in CV 28 deleted or marked as reserved.
+02.12.2018 | 2.1 / 2.2 | Editorial: Explanation of "Value range" of the CV table and description of CVs 17 and 18 for mobile and accessory decoders. CV #28 definition adapted to [RCN-217]. New values for CV96 according to the new RCN-227.
+22.07.2017 | 2.1 / 2.2 / 3.1 | Any values in CV1 for other protocols, DCC may be disabled. Long address 0 in CVs 17 and 18 explicitly forbidden. Assignment of the pages reached via CVs 31 and 32 to CVs 1 to 1024, reservation of 2 pages reserved via CVs 31 and 32. CVs 17 and 18 for accessory decoders.
+31.07.2016 | All | First draft
+
+Copyright 2025 RailCommunity – Association of Digital Model Railroad Product Manufacturers e.V.

--- a/docs/RCN-226.EN.MD
+++ b/docs/RCN-226.EN.MD
@@ -1,0 +1,230 @@
+# RCN-226
+
+## DCC Protocol
+
+```
+Special Values for Configuration
+```
+```
+Date of Issue
+03.08.2014
+```
+```
+RailCommunity – Association
+of Digital Model Railroad
+Product Manufacturers
+```
+## Contents
+
+```
+1 General ......................................................................................................................... 1
+1.1 Purpose of the Standard ........................................................................................................... 1
+2 CV #8 ................................................................................................................................... 2
+2.1 Standardized Values ............................................................................................................ 2
+2.2 Non-Standardized Values ................................................................................................... 2
+3 CV #7 ................................................................................................................................... 2
+3.1 Configuration of Addressless Devices ................................................................................. 2
+3.2 Setting of Special Configurations ....................................................................... 3
+Appendix A: References to other Standards ............................................................................... 3
+A.1 Normative References .................................................................................................... 3
+A.2 Informative References ................................................................................................... 3
+Appendix B: History ................................................................................................................. 3
+Appendix C: Values for CV #7 ................................................................................................... 4
+C.1 Lenz .............................................................................................................................. 4
+C.2 Tams ............................................................................................................................. 4
+Appendix D: Values for CV #8 ................................................................................................... 5
+D.1 Lenz .............................................................................................................................. 5
+D.2 Massoth ........................................................................................................................ 5
+D.3 Viessmann .................................................................................................................... 5
+D.4 Zimo ............................................................................................................................. 6
+```
+
+## 1 General
+
+### 1.1 Purpose of the Standard
+
+This standard describes the values that are written to the two non-modifiable CVs 7 and 8
+to perform special configurations. This also includes the
+configuration of devices that do not have their own address, such as boosters.
+
+Some of these values are written only in normal operation, others only in
+programming mode. This depends on the type of change desired and is specified in the
+respective section.
+
+## 2 CV #8
+
+### 2.1 Standardized Values
+
+When writing the value 8 to CV #8 in programming mode, a decoder must reset all CVs
+back to the factory settings with the default values specified in the decoder's manual.
+These must be fixed values that are independent of any
+previous programming or other settings.
+
+This is the only standardized value.
+
+### 2.2 Non-Standardized Values
+
+For partial or other setting-dependent resetting of the decoder,
+any values other than 8 can be used. Examples are resetting with
+the exception of the address and the speed table, restoring saved
+configuration tables, or resetting taking into account data from
+sound projects.
+
+Furthermore, it is possible to call up certain predefined configurations by writing a
+value to CV #8.
+
+For security reasons, only commands in programming mode should be allowed for all reset actions and configuration changes.
+
+## 3 CV #7
+
+### 3.1 Configuration of Addressless Devices
+
+This configuration variable 7 is used by devices that do not have their own address
+and for which a connection to a programming track is not possible or reasonable. Therefore,
+the configuration commands in operating mode are recognized regardless of the address,
+but only the non-modifiable CV #7 is used. This is to avoid unwanted effects in
+decoders with an address.
+
+In addition, a single defined value, the key value, must first be written to prepare the
+device for receiving the actual values. After that, a value for
+configuration can be written. After that, or if no value was written after
+a specified time, the reception of configuration values must be disabled again and
+a new writing of the key value is required for configuration.
+
+The manufacturer ID according to CV #8 in decoders is to be used as the key value.
+For reasons of grandfathering, the company Lenz can continue to use 50.
+
+### 3.2 Setting of Special Configurations
+
+If writing to CV #7 is used to set special configurations in decoders,
+only write commands in programming mode may be observed.
+Write commands to CV #7 in operating mode must be ignored by all decoders
+so that there are no unintentional overlaps with the configuration of addressless devices.
+
+## Appendix A: References to other Standards
+
+### A.1 Normative References
+
+No other standards need to be adhered to to comply with this standard.
+
+### A.2 Informative References
+
+The standards and documents listed here are for informational purposes only and are
+not part of this standard.
+
+[RCN225] RCN-225 DCC Configuration Variables^1
+
+## Appendix B: History
+
+```
+Date Changes since the previous version
+```
+12.09.2014 First Version
+
+(^1) RCN-225 is still in preparation at the time of creation of this standard. It will be created on the basis of
+NMRA S-9.2.2.
+
+## Appendix C: Values for CV #7
+
+Below are the values used for the existing devices, sorted by manufacturer.
+This table is for informational purposes only and is not part of the
+standard to be adhered to.
+
+### C.1 Lenz
+
+Devices: Booster LV102
+Booster part of the command station LZV100
+Key value: 50
+
+Values for configuration:
+
+Value Range | Function
+--- | ---
+22 - 44 | Track voltage between 11 V and 22 V in 0.5 V steps, Voltage [V] = Value / 2
+90 | E-line active
+91 | E-line not active
+92 | Switch off RailCom Cutout
+93 | Switch on RailCom Cutout
+96 | Display LV102 version via LED
+99 | Reset to factory settings
+
+### C.2 Tams
+
+Devices: Booster B-4
+Key value: 62
+
+Values for configuration:
+
+Value Range | Function
+--- | ---
+8 | Reset to factory settings
+10 - 24 | Track voltage between 10 V and 24 V in 1 V steps, Voltage [V] = Value
+34 - 40 | Restart time after short circuit in seconds = Value - 30
+42 - 45 | Max. track current (shutdown current) [A] = Value - 40
+51 | Switch on RailCom Cutout
+52 | Switch off RailCom Cutout
+71 | Switch on with turnout command
+72 | Switch off with turnout command
+73 | Switch with turnout command (programming mode)
+74 | Switch on watchdog
+75 | Switch off watchdog
+76 | Watchdog (programming mode)
+81 - 86 | Limit for short circuit warning (Value - 81) * 0.2 [A]
+100 - 109 | additional restart time after 5 short circuits (Value - 100) * 10 [s]
+
+## Appendix D: Values for CV #8
+
+Below are the values used for the existing devices, sorted by manufacturer.
+This table is for informational purposes only and is not part of the
+standard to be adhered to.
+
+### D.1 Lenz
+
+Decoder | Value | Function
+--- | --- | ---
+All | 33 | Reset to factory settings like Value = 8
+Silver+ PluX12 | 90 | Standard setting
+Silver+ PluX12 | 91 | Tillig diesel and electric locomotives
+Silver+ PluX12 | 92 | Tillig diesel and electric locomotives with high beam headlights
+
+### D.2 Massoth
+
+Decoder | Value | Function
+--- | --- | ---
+New from 2014 | 11 | Reset of the most important basic settings
+New from 2014 | 16 | (Emergency) removal of the programming lock CV15+16
+New from 2014 | 22 | Reset of the functions for: LV, LH, FA1, FA2
+New from 2014 | 33 | Reset of the functions for: FA3 .. FA6
+New from 2014 | 44 | Reset of the functions for: FA7 .. FA10
+New from 2014 | 66 | Reset of the driving and motor settings
+New from 2014 | 111 | Reset of the sound functions: Function mapping
+New from 2014 | 122 | Reset of the sound functions: Basic settings
+New from 2014 | 133 | Reset of sound functions: Volumes
+New from 2014 | 222 | Removal of a "manufacturer lock"
+
+### D.3 Viessmann
+
+Decoder | Value | Function
+--- | --- | ---
+In-house developments | 9 | Reset of all CVs except address and speed curve
+
+### D.4 Zimo
+
+At Zimo, CV sets are continuously defined for specific applications and are then available in
+the software common to all decoders. If there is an "All" in the Decoder column,
+this naturally means that this applies to decoders that were delivered after the definition of the CV set
+or have received a software update.
+
+Decoder | Value | Function
+--- | --- | ---
+All | 0 | Reset of all CVs to values according to the operating manual
+MX634C and MX634D | 3 | Conversion of MX634D to MX634C (AUX3 and AUX4 logic level)
+MX634C and MX634D | 4 | Conversion of MX634C to MX634D (AUX3 and AUX4 amplified outputs)
+All | 8 | Hard Reset: Reset of all CVs to the last selected CV set, e.g., the manufacturer-specific settings from Set #14
+All | 9 | Hard Reset and setting to old LGB-MZS technology (14 speed steps, pulse chain reception)
+All | 10 - 13 | Selection of predefined CV sets
+All | 14 - 16 | Roco-specific CV sets without RailCom
+All | 17 - 28 | Roco-specific CV sets with RailCom
+All | 29 - 33 | Fleischmann-specific CV sets
+
+Copyright 2014 RailCommunity – Association of Digital Model Railroad Product Manufacturers e.V.

--- a/docs/RCN-227.EN.MD
+++ b/docs/RCN-227.EN.MD
@@ -1,0 +1,357 @@
+# RCN-227
+
+## DCC-Protocol
+
+```
+Extended Function Mapping
+```
+```
+Date of Issue
+02. 12 .2018
+```
+```
+RailCommunity – Association
+of Digital Model Railroad
+Product Manufacturers
+```
+## Contents
+
+1 General ............................................................................................................................. 1
+
+```
+1.1 Purpose of the Standard ........................................................................................................... 1
+1.2 Definition of Terms .......................................................................................................... 1
+1.3 Requirements .............................................................................................................. 2
+```
+2 Function Mapping System with CVs per Function ........................................................... 2
+
+3 Function Mapping System with CVs per Output ........................................................... 3
+
+```
+3.1 Version 1: Matrix .......................................................................................................... 3
+3.2 Version 2: Function Number ....................................................................................... 3
+3.3 Version 3: Function or Binary State Number ...................................................... 4
+```
+4 Selection of Function Mapping .......................................................................................... 5
+
+Appendix A: References to other Standards .................................................................................. 6
+
+```
+A.1 Normative References .................................................................................................... 6
+A.2 Informative References ................................................................................................... 6
+```
+Appendix B: History ..................................................................................................................... 6
+
+## 1 General
+
+### 1.1 Purpose of the Standard
+
+This standard describes an extended system for function mapping between the
+functions within the DCC protocol and the outputs of a decoder. This
+function mapping system allows for any assignment between up to 32
+functions to 24 outputs, thus taking into account the increased number of functions compared to the mapping via
+configuration variables 33 to 46.
+At the same time, this function mapping is designed so that it can still be managed without a special
+configuration program.
+
+### 1.2 Definition of Terms
+
+In this standard, the terms function and output are used as follows:
+
+Functions are the functions defined in the DCC protocol (or any other protocol for
+data transmission to the locomotive).
+
+
+Outputs are the actions controlled by the decoder. These outputs can be
+physical function outputs for controlling external loads, but also other
+actions such as sounds or changes in driving behavior, e.g., for shunting mode.
+
+CV refers to the Configuration Variables.
+
+### 1.3 Requirements
+
+To comply with this standard, a decoder must support the function mapping system described here
+for all functions received via the protocol and all outputs
+of the decoder.
+
+However, other function mapping systems may also be supported, e.g., via
+configuration variables 33 to 46 or a manufacturer-specific system.
+
+Configuration variable 96 must be supported as described in [RCN225].
+
+## 2 Function Mapping System with CVs per Function
+
+To have sufficient memory space available, a block of 256 CVs selected via CVs 31 and 32
+is used, which are then accessible via CVs 257 to 512. To select the block for function mapping,
+CV 31 must be set to the value 0 and CV 32 to the value 40.
+
+Four bytes are reserved for each function and direction. I.e., for function F0 forward
+CVs 257 to 260, for F0 reverse CVs 261 to 264, for F1 forward CVs 265 to
+268, for F1 reverse CVs 269 to 272, etc.
+
+Each set bit links an output with a function. The first three bytes per
+function and direction activate outputs 1 to 24, where output 1 is controlled by bit 0 of the
+first byte and output 24 by bit 7 of the third byte. If an output is
+controlled by multiple functions, they are OR-linked, i.e., the output is
+active when one or more functions control this output.
+
+The fourth byte per function and direction defines a function that prevents the activation of
+the outputs via this function and direction. The number of the
+function – i.e., 0 for F0, 1 for F1, 2 for F2, etc. – is entered. A value of 255 means that
+no function prevents activation.
+
+
+## 3 Function Mapping System with CVs per Output
+
+### 3.1 Version 1: Matrix
+
+To have sufficient memory space available, a block of 256 CVs selected via CVs 31 and 32
+is used, which are then accessible via CVs 257 to 512. To select the block for function mapping,
+CV 31 must be set to the value 0 and CV 32 to the value 41.
+
+Four bytes are reserved for each output and direction of travel. I.e., for output A forward
+CVs 257 to 260, for output A reverse CVs 261 to 264, for output B forward
+CVs 265 to 268, for output B reverse CVs 269 to 272, etc.
+
+Each set bit links an output with a function. Bits 0
+to 7 of the first byte correspond to functions F0 to F7, those of the second byte to F8 to F15, those of the
+third byte to F16 to F23, and those of the fourth byte to F24 to F31.
+
+This allows each of the maximum 32 outputs to be controlled by any number of functions.
+However, control via binary states or blocking an output is
+not possible.
+
+### 3.2 Version 2: Function Number
+
+To have sufficient memory space available, a block of 256 CVs selected via CVs 31 and 32
+is used, which are then accessible via CVs 257 to 512. To select the block for function mapping,
+CV 31 must be set to the value 0 and CV 32 to the value 42.
+
+Four bytes are reserved for each output and direction of travel. I.e., for output A forward
+CVs 257 to 260, for output A reverse CVs 261 to 264, for output B forward
+CVs 265 to 268, for output B reverse CVs 269 to 272, etc.
+
+Each byte contains a function number. If the number is greater than 28 (may need to be adjusted to
+68), this number is interpreted as a binary state. The value 255 indicates an
+inactive byte. The first three bytes switch the output on. The fourth byte switches the
+output off regardless of the state of other functions.
+
+This allows each of the maximum 32 outputs to be controlled by up to four functions or binary states
+up to binary state 254. Since no bitmasks need to be calculated, this
+system should be particularly simple for the user.
+
+Example:
+Light control on a diesel or electric locomotive. The following logic should be achieved:
+
+a. "normal" light change via F0
+b. Because this is not prototypical with a train: F1 blocks the lights on driver's cab 1, F2 blocks
+the lights on driver's cab 2.
+c. The shunting mode via F6 should also switch on both white lights and the red lights
+off.
+d. Function F23 should switch on "parking light" with red on both sides.
+
+
+Programming:
+
+a) b) & c) --- d)
+
+Output white 1 fwd. CV257 = F0 = 0 CV258 = F6 = 6 CV259 = 255 CV260 = F1 = 1
+
+Output white 1 rev. CV261 = 255 CV262 = F6 = 6 CV263 = 255 CV260 = F1 = 1
+
+Output white 2 fwd. CV265 = 255 CV266 = F6 = 6 CV267 = 255 CV268 = F2 = 2
+
+Output white 2 rev. CV269 = F0 = 0 CV270 = F6 = 6 CV271 = 255 CV268 = F2 = 2
+
+Output red 1 fwd. CV273 = 255 CV274 = F23 = 23 CV275 = 255 CV275 = F1 = 1
+
+Output red 1 rev. CV277 = F0 = 0 CV274 = F23 = 23 CV279 = 255 CV275 = F1 = 1
+
+Output red 2 fwd. CV281 = F0 = 0 CV282 = F23 = 23 CV283 = 255 CV284 = F2 = 2
+
+Output red 2 rev. CV285 = 255 CV282 = F23 = 23 CV287 = 255 CV288 = F2 = 2
+
+Problem: For shunting mode and "parking light", the other functions must be switched off.
+
+### 3.3 Version 3: Function or Binary State Number
+
+To have sufficient memory space available, a block of 256 CVs selected via CVs 31 and 32
+is used, which are then accessible via CVs 257 to 512. To select the block for function mapping,
+CV 31 must be set to the value 0 and CV 32 to the value 43.
+
+Eight bytes are reserved for each output. I.e., for output A CVs 257 to 264, for
+output B CVs 265 to 272, for output C CVs 273 to 280, etc.
+
+The first four bytes denote a function and direction. The function number
+0 - 63 is stored in bits 0 to 5. The directional dependence is defined in bits 6 and 7 as
+follows:
+
+```
+Bit
+7
+```
+```
+Bit
+6
+```
+```
+Calculation Rule Action
+```
+```
+0 0 Function number Function acts regardless of direction
+```
+```
+0 1 Function number + 64 Function acts only forwards
+```
+```
+1 0 Function number + 128 Function acts only backwards
+```
+```
+1 1 Function number + 192
+```
+```
+Function blocks the output regardless of the
+state of other functions
+```
+The value 255 indicates an inactive byte.
+
+The second four bytes contain two byte-pairs, with which either functions or
+binary state controls can be selected. In the first of the two bytes are the
+higher 7 bits of the number of the function or binary state control, in the second
+byte the 8 lower bits are stored. Numbers up to 28 inclusive (may need to be adjusted to
+68) denote functions, values above that denote binary state controls. The
+most significant bit (bit 7) in the first byte is set if this function or
+binary state control is to block the output. Controls via the two byte-
+pairs in the second four bytes always operate independently of direction.
+
+If both bytes of a pair have the value 255, this byte-pair is inactive.
+
+This allows each of the maximum 32 outputs to be controlled by up to six functions or binary states
+up to binary state 32767. Blocking the output via binary state
+32767 is not possible. Also, there is no directional dependence of the binary states.
+
+Example:
+Light control on a diesel or electric locomotive. The following logic should be achieved:
+
+a. "normal" light change via F0
+b. Because this is not prototypical with a train: F1 blocks the lights on driver's cab 1, F2 blocks
+the lights on driver's cab 2.
+c. The shunting mode via F6 should also switch on both white lights and the red lights
+off.
+d. Function F23 should switch on "parking light" with red on both sides.
+
+Programming:
+
+a) b) c) d)
+
+Output white
+
+1
+
+CV257 =
+
+F0 + 64 = 64
+
+CV258 =
+
+F1 + 192 = 193
+
+CV259 =
+
+F6 = 6
+
+CV260 =
+
+F23 + 192 = 215
+
+Output white
+2
+
+CV265 =
+
+F0 + 128 = 128
+
+CV266 =
+
+F2 + 192 = 194
+
+CV267 =
+
+F6 = 6
+
+CV268 =
+
+F23 + 192 = 215
+
+Output red 1
+
+CV273 =
+
+F0 + 128 = 128
+
+CV274 =
+
+F1 + 192 = 193
+
+CV275 =
+
+F6 + 192 = 198
+
+CV275 =
+
+F23 = 23
+
+Output red 2
+
+CV281 =
+
+F0 + 64 = 64
+
+CV282 =
+
+F2 + 192 = 194
+
+CV283 =
+
+F6 + 192 = 198
+
+CV284 =
+
+F23 = 23
+
+The unlisted CVs between CV261 and CV288 have the value 255.
+
+It can be seen that there is only a directional dependence in the first byte. Problem:
+For "parking", the shunting mode must be disengaged, otherwise it remains dark. Likewise,
+F1 and F2 should be switched off for shunting mode and "parking light". These problems
+could be solved by having a switch-off only affect the preceding bytes. But then
+the order of the bytes would no longer be arbitrary.
+
+## 4 Selection of Function Mapping
+
+If multiple function mapping systems are implemented in a decoder, the
+user can select the desired system via the configuration variable CV 96 as specified in [RCN225].
+
+
+## Appendix A: References to other Standards
+
+### A.1 Normative References
+
+The standard listed here must be adhered to in whole or to the extent specified in the citation
+to comply with this standard.
+
+[RCN225] RCN-225 DCC Configuration Variables
+
+### A.2 Informative References
+
+The standards and documents listed here are for informational purposes only and are
+not part of this standard.
+
+## Appendix B: History
+
+```
+Date Chapter Changes compared to the previous version
+```
+02.12.2018 All First version
+
+Copyright 2018 RailCommunity – Association of Digital Model Railroad Product Manufacturers e.V.


### PR DESCRIPTION
- Updates `LIGHT_AND_AUX_CONCEPT.MD` to adopt RCN-227 as the user-facing standard for function mapping.
- Adds a detailed, phased implementation roadmap for RCN-227 to the concept document.
- Translates German RCN documents (200, 225, 226, 227) into English, creating `.EN.MD` sibling files.
- Restores the German RCN-227 document per user request.