### PR TITLE
feat: Implement runtime multi-protocol detection

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = xiao_dcc
+default_envs = xiao_multiprotocol
 
 [env]
 platform = https://github.com/Seeed-Studio/platform-seeedboards.git
@@ -21,21 +21,12 @@ lib_deps =
     https://github.com/chatelao/xDuinoRails_MotorControl.git
     denyssene/SimpleKalmanFilter
     adafruit/Adafruit NeoPixel
+    NmraDcc
 
-[env:xiao_dcc]
+[env:xiao_multiprotocol]
 extends = env
 build_flags =
-    -UPROTOCOL_MM
-    -UPROTOCOL_DCC
-    -DPROTOCOL_DCC
-    -D USE_RP2040_LOWLEVEL
-
-[env:xiao_mm]
-extends = env
-build_flags =
-    -UPROTOCOL_MM
-    -UPROTOCOL_DCC
-    -DPROTOCOL_MM
+    -DPROTOCOL_AUTO
     -D USE_RP2040_LOWLEVEL
 
 [env:native]

--- a/firmware/src/ProtocolManager.cpp
+++ b/firmware/src/ProtocolManager.cpp
@@ -1,0 +1,31 @@
+#include "ProtocolManager.h"
+
+ProtocolManager::ProtocolManager(CVManager& cvManager) : _cvManager(cvManager), _activeProtocol(Protocol::UNDECIDED) {}
+
+void ProtocolManager::begin() {
+    uint8_t cv12 = _cvManager.readCV(CV_POWER_SOURCE_LOCK);
+    _dccEnabled = (cv12 & CV12_DCC_ENABLE_BIT) == 0;
+    _mmEnabled = (cv12 & CV12_MM_ENABLE_BIT) == 0;
+}
+
+Protocol ProtocolManager::getActiveProtocol() const {
+    if (!_dccEnabled && _mmEnabled) {
+        return Protocol::MM;
+    }
+    if (_dccEnabled && !_mmEnabled) {
+        return Protocol::DCC;
+    }
+    return _activeProtocol;
+}
+
+void ProtocolManager::notifyDccPacket() {
+    if (_activeProtocol == Protocol::UNDECIDED && _dccEnabled) {
+        _activeProtocol = Protocol::DCC;
+    }
+}
+
+void ProtocolManager::notifyMmPacket() {
+    if (_activeProtocol == Protocol::UNDECIDED && _mmEnabled) {
+        _activeProtocol = Protocol::MM;
+    }
+}

--- a/firmware/src/ProtocolManager.h
+++ b/firmware/src/ProtocolManager.h
@@ -1,0 +1,28 @@
+#ifndef PROTOCOL_MANAGER_H
+#define PROTOCOL_MANAGER_H
+
+#include "cv_definitions.h"
+#include "CVManager.h"
+
+enum class Protocol {
+    UNDECIDED,
+    DCC,
+    MM
+};
+
+class ProtocolManager {
+public:
+    ProtocolManager(CVManager& cvManager);
+    void begin();
+    Protocol getActiveProtocol() const;
+    void notifyDccPacket();
+    void notifyMmPacket();
+
+private:
+    CVManager& _cvManager;
+    Protocol _activeProtocol;
+    bool _dccEnabled;
+    bool _mmEnabled;
+};
+
+#endif // PROTOCOL_MANAGER_H

--- a/firmware/src/cv_definitions.h
+++ b/firmware/src/cv_definitions.h
@@ -20,7 +20,7 @@
 #define CV_PULSE_WIDTH_PERIOD 9
 #define CV_EMF_FEEDBACK_CUTOUT 10
 #define CV_PACKET_TIME_OUT 11
-#define CV_POWER_SOURCE_CONVERSION 12
+#define CV_POWER_SOURCE_LOCK 12
 #define CV_ALT_MODE_FUNC_STATUS_F1_F8 13
 #define CV_ALT_MODE_FUNC_STATUS_FL_F9_F12 14
 #define CV_DECODER_LOCK_1 15
@@ -51,6 +51,10 @@
 #define CV_USER_ID_2 106
 
 
+// CV 12 Power Source Lock Bits (RCN-200)
+#define CV12_DCC_ENABLE_BIT 0b00000001       // Bit 0: 0=DCC Enabled, 1=DCC Disabled
+#define CV12_MM_ENABLE_BIT 0b00000010        // Bit 1: 0=MM Enabled, 1=MM Disabled
+
 // CV 29 Configuration Bits (from NmraDcc.h)
 #define CV29_DIRECTION_BIT 0b00000001        // Bit 0: Locomotive Direction
 #define CV29_FL_LOCATION_BIT 0b00000010       // Bit 1: F0 Light Location
@@ -72,6 +76,7 @@
 #define DECODER_DEFAULT_EXT_ADDRESS_LSB 232 // Low byte for address 1000
 #define DECODER_DEFAULT_MANUFACTURER_ID 165 // NMRA ID for DIY/Home-built decoders
 #define DECODER_DEFAULT_CV29_CONFIG 6       // Enable 28/128 speed steps and analog mode
+#define DECODER_DEFAULT_POWER_SOURCE_LOCK 0 // Enable both DCC and MM by default
 #define DECODER_DEFAULT_VERSION_ID 1        // Firmware version 1
 
 // RCN-225 Default Function Mappings (CVs 33-46)

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -16,9 +16,9 @@ XDuinoRails_MotorDriver motor(MOTOR_PIN_A, MOTOR_PIN_B, MOTOR_BEMF_A_PIN, MOTOR_
 FunctionManager functionManager;
 CVManager cvManager;
 PhysicalOutputManager physicalOutputManager;
+ProtocolManager protocolManager(cvManager);
 
 
-#if defined(PROTOCOL_DCC)
 // --- DCC-Specific Includes and Objects ---
 #define NMRA_DCC_PROCESS_MULTIFUNCTION
 #include <NmraDcc.h>
@@ -27,12 +27,6 @@ PhysicalOutputManager physicalOutputManager;
 
 NmraDcc dcc;
 
-// --- DCC Callback Prototypes ---
-void notifyDccSpeed(uint16_t Addr, DCC_ADDR_TYPE AddrType, uint8_t Speed, DCC_DIRECTION Dir, DCC_SPEED_STEPS SpeedSteps);
-void notifyDccFunc(uint16_t Addr, DCC_ADDR_TYPE AddrType, FN_GROUP FuncGrp, uint8_t FuncState);
-void notifyCVChange(uint16_t CV, uint8_t Value);
-
-#elif defined(PROTOCOL_MM)
 // --- MM-Specific Includes and Objects ---
 #include <MaerklinMotorola.h>
 
@@ -44,7 +38,13 @@ MaerklinMotorola MM(MM_SIGNAL_PIN);
 void mm_isr() {
   MM.PinChange();
 }
-#endif
+
+
+// --- DCC Callback Prototypes ---
+void notifyDccSpeed(uint16_t Addr, DCC_ADDR_TYPE AddrType, uint8_t Speed, DCC_DIRECTION Dir, DCC_SPEED_STEPS SpeedSteps);
+void notifyDccFunc(uint16_t Addr, DCC_ADDR_TYPE AddrType, FN_GROUP FuncGrp, uint8_t FuncState);
+void notifyCVChange(uint16_t CV, uint8_t Value);
+void notifyDccMsg(DCC_MSG *p);
 
 
 void setup() {
@@ -52,6 +52,7 @@ void setup() {
   motor.begin();
   cvManager.begin();
   physicalOutputManager.begin();
+  protocolManager.begin();
 
   // --- Load Configuration ---
   // The CVLoader reads from the CVManager and populates the FunctionManager
@@ -59,10 +60,10 @@ void setup() {
   CVLoader::loadCvToFunctionManager(cvManager, functionManager, physicalOutputManager);
 
   // --- Protocol-Specific Setup ---
-#if defined(PROTOCOL_DCC)
   dcc.pin(DCC_SIGNAL_PIN, false);
   dcc.init(MAN_ID_DIY, 1, FLAGS_MY_ADDRESS_ONLY, 0);
   dcc.setCVWriteCallback(notifyCVChange);
+  dcc.setDccMsgCallback(notifyDccMsg);
 
   // Sync our CVManager state with the DCC library's internal state
   dcc.setCV(CV_MULTIFUNCTION_PRIMARY_ADDRESS, cvManager.readCV(CV_MULTIFUNCTION_PRIMARY_ADDRESS));
@@ -70,18 +71,12 @@ void setup() {
   dcc.setCV(CV_DECODER_VERSION_ID, cvManager.readCV(CV_DECODER_VERSION_ID));
   dcc.setCV(CV_DECODER_CONFIGURATION, cvManager.readCV(CV_DECODER_CONFIGURATION));
 
+  attachInterrupt(digitalPinToInterrupt(MM_SIGNAL_PIN), mm_isr, CHANGE);
+
   // Apply motor settings from CVs
   notifyCVChange(CV_START_VOLTAGE, cvManager.readCV(CV_START_VOLTAGE));
   notifyCVChange(CV_ACCELERATION_RATE, cvManager.readCV(CV_ACCELERATION_RATE));
   notifyCVChange(CV_DECELERATION_RATE, cvManager.readCV(CV_DECELERATION_RATE));
-#elif defined(PROTOCOL_MM)
-  attachInterrupt(digitalPinToInterrupt(MM_SIGNAL_PIN), mm_isr, CHANGE);
-
-  // Apply motor settings from CVs
-  motor.setStartupKick(cvManager.readCV(CV_START_VOLTAGE), MOTOR_STARTUP_KICK_DURATION);
-  motor.setAcceleration(cvManager.readCV(CV_ACCELERATION_RATE) * 2.5);
-  motor.setDeceleration(cvManager.readCV(CV_DECELERATION_RATE) * 2.5);
-#endif
 }
 
 void loop() {
@@ -90,34 +85,49 @@ void loop() {
   uint32_t delta_ms = current_millis - last_millis;
   last_millis = current_millis;
 
-#if defined(PROTOCOL_DCC)
-  dcc.process();
-#elif defined(PROTOCOL_MM)
-  MM.Parse();
-  MaerklinMotorolaData* data = MM.GetData();
-  if (data && !data->IsMagnet && data->Address == MM_ADDRESS) {
-    functionManager.setFunctionState(0, data->Function);
+  switch (protocolManager.getActiveProtocol()) {
+    case Protocol::DCC:
+      dcc.process();
+      break;
+    case Protocol::MM:
+      MM.Parse();
+      MaerklinMotorolaData* data = MM.GetData();
+      if (data && !data->IsMagnet && data->Address == MM_ADDRESS) {
+        protocolManager.notifyMmPacket();
+        functionManager.setFunctionState(0, data->Function);
 
-    if (data->ChangeDir) {
-      motor.setDirection(!motor.getDirection());
-    } else if (data->Stop) {
-      motor.setTargetSpeed(0);
-    } else {
-      uint8_t pps = map(data->Speed, 0, 14, 0, 200);
-      motor.setTargetSpeed(pps);
-    }
-    // Update function manager with MM state
-    functionManager.setDirection(motor.getDirection() ? DECODER_DIRECTION_FORWARD : DECODER_DIRECTION_REVERSE);
-    functionManager.setSpeed(motor.getTargetSpeed());
+        if (data->ChangeDir) {
+          motor.setDirection(!motor.getDirection());
+        } else if (data->Stop) {
+          motor.setTargetSpeed(0);
+        } else {
+          uint8_t pps = map(data->Speed, 0, 14, 0, 200);
+          motor.setTargetSpeed(pps);
+        }
+        // Update function manager with MM state
+        functionManager.setDirection(motor.getDirection() ? DECODER_DIRECTION_FORWARD : DECODER_DIRECTION_REVERSE);
+        functionManager.setSpeed(motor.getTargetSpeed());
+      }
+      break;
+    case Protocol::UNDECIDED:
+      dcc.process();
+      MM.Parse();
+      MaerklinMotorolaData* mm_data = MM.GetData();
+      if (mm_data && !mm_data->IsMagnet) {
+        protocolManager.notifyMmPacket();
+      }
+      break;
   }
-#endif
 
   motor.update();
   functionManager.update(delta_ms);
 }
 
+void notifyDccMsg(DCC_MSG *p) {
+    protocolManager.notifyDccPacket();
+}
+
 // --- DCC Callback Implementations ---
-#if defined(PROTOCOL_DCC)
 void notifyDccSpeed(uint16_t Addr, DCC_ADDR_TYPE AddrType, uint8_t Speed, DCC_DIRECTION Dir, DCC_SPEED_STEPS SpeedSteps) {
   if (Addr == dcc.getAddr()) {
     bool is_forward = (Dir == DCC_DIR_FWD);
@@ -174,4 +184,3 @@ void notifyCVChange(uint16_t CV, uint8_t Value) {
         // but that's a complex operation. For now, motor CVs are live-updated.
     }
 }
-#endif


### PR DESCRIPTION
This commit implements runtime multi-protocol (DCC and Märklin-Motorola) detection, replacing the previous compile-time protocol selection.

A new `ProtocolManager` class has been introduced to handle protocol detection and state management. The decoder now initializes both DCC and MM protocols at startup and determines the active protocol based on the first valid packet received.

CV 12 (`CV_POWER_SOURCE_LOCK`) has been implemented to allow users to force a specific protocol, as per the RCN-200 standard.

The `platformio.ini` file has been updated to use a single `xiao_multiprotocol` build environment.